### PR TITLE
fix(storage): prioritize populated CliOS USB drives

### DIFF
--- a/frontend/shared_pages/SystemPage.qml
+++ b/frontend/shared_pages/SystemPage.qml
@@ -67,7 +67,7 @@ Item {
                 Column { anchors.centerIn: parent; spacing: 5
                     Text { anchors.horizontalCenter: parent.horizontalCenter; text: S.UiState.usbConnected ? "CLÉ USB" : (S.UiState.internalStorage ? "CARTE SD" : "MODE RAM"); color: S.UiState.usbConnected ? T.StyleManager.success : (S.UiState.internalStorage ? T.StyleManager.warning : T.StyleManager.danger); font.pixelSize: 25; font.bold: true }
                     Text { anchors.horizontalCenter: parent.horizontalCenter; text: S.UiState.fixed(S.UiState.storageFreeMb, 0, "0") + " MB libres"; color: T.StyleManager.textSecondary; font.pixelSize: 16 }
-                    Text { anchors.horizontalCenter: parent.horizontalCenter; text: S.UiState.usbConnected ? S.UiState.storageMount : S.UiState.storageMode; color: T.StyleManager.textSecondary; font.pixelSize: 11; elide: Text.ElideMiddle; width: 190; horizontalAlignment: Text.AlignHCenter }
+                    Text { anchors.horizontalCenter: parent.horizontalCenter; text: S.UiState.usbConnected ? S.UiState.storageMount : (S.UiState.storageDiagnostic || S.UiState.storageMode); color: T.StyleManager.textSecondary; font.pixelSize: 11; elide: Text.ElideRight; width: 250; horizontalAlignment: Text.AlignHCenter }
                 }
             }
             Card { Layout.fillWidth: true; Layout.fillHeight: true; title: "CAN"; Metric { anchors.centerIn: parent; width: parent.width; label: "Service moteur"; value: S.UiState.serviceHealth.CAN_Moteur ? S.UiState.serviceHealth.CAN_Moteur.status : "—"; alignment: Text.AlignHCenter; valueSize: 26 } }

--- a/installation/usr/local/libexec/clios-usb-mount
+++ b/installation/usr/local/libexec/clios-usb-mount
@@ -58,26 +58,34 @@ mount_device() {
     if [[ -n "$source" ]]; then
         [[ "$(readlink -f "$source" 2>/dev/null || true)" == "$(readlink -f "$DEVICE")" ]] \
             || fail "${MOUNT_POINT} est déjà utilisé par ${source}"
-        return 0
+    else
+        mkdir -p "$MOUNT_POINT"
+        group_id="$(getent group clios | cut -d: -f3)"
+        [[ -n "$group_id" ]] || fail "le groupe clios est introuvable"
+
+        case "$filesystem" in
+            vfat|msdos|exfat|ntfs|ntfs3)
+                mount -o "rw,nosuid,nodev,noexec,uid=0,gid=${group_id},dmask=0002,fmask=0113" \
+                    "$DEVICE" "$MOUNT_POINT"
+                ;;
+            *)
+                mount -o rw,nosuid,nodev,noexec "$DEVICE" "$MOUNT_POINT"
+                ;;
+        esac
     fi
 
-    mkdir -p "$MOUNT_POINT"
-    group_id="$(getent group clios | cut -d: -f3)"
-    [[ -n "$group_id" ]] || fail "le groupe clios est introuvable"
-
-    case "$filesystem" in
-        vfat|msdos|exfat|ntfs|ntfs3)
-            mount -o "rw,nosuid,nodev,noexec,uid=0,gid=${group_id},dmask=0002,fmask=0113" \
-                "$DEVICE" "$MOUNT_POINT"
-            ;;
-        *)
-            mount -o rw,nosuid,nodev,noexec "$DEVICE" "$MOUNT_POINT"
-            ;;
-    esac
-
-    mkdir -p "${MOUNT_POINT}/clios"
-    chown root:clios "${MOUNT_POINT}/clios" 2>/dev/null || true
-    chmod 2775 "${MOUNT_POINT}/clios" 2>/dev/null || true
+    local clios_root managed_dir
+    clios_root="${MOUNT_POINT}/clios"
+    mkdir -p "$clios_root"
+    chown root:clios "$clios_root" 2>/dev/null || true
+    chmod 2775 "$clios_root" 2>/dev/null || true
+    # Ne touche pas aux autres contenus de la clé (notamment les anciens
+    # exports). Seuls les répertoires runtime connus sont préparés.
+    for managed_dir in dash_save logs trips trips_mock config diagnostics; do
+        mkdir -p "${clios_root}/${managed_dir}"
+        chown root:clios "${clios_root}/${managed_dir}" 2>/dev/null || true
+        chmod 2775 "${clios_root}/${managed_dir}" 2>/dev/null || true
+    done
     log "${DEVICE} (${filesystem}) monté sur ${MOUNT_POINT}"
 }
 

--- a/src/storage_manager.py
+++ b/src/storage_manager.py
@@ -370,16 +370,54 @@ class StorageManager:
             self._logger.debug(message, extra={"error_code": error_code})
 
     def _switch_to_usb(self, usb_root: str) -> None:
+        previous_root = self.get_writable_root()
         try:
             self._ensure_tree(usb_root)
-            self._migrate_without_overwrite(self.get_writable_root(), usb_root)
-        except OSError:
+            self._verify_usb_tree_writable(usb_root)
+        except OSError as exc:
+            self._set_usb_diagnostic(
+                f"Dossier CliOS inutilisable: {usb_root}: {exc}",
+                "USB_ROOT_PREPARE_FAILED",
+            )
             return
 
+        migration_error = None
+        try:
+            self._migrate_without_overwrite(previous_root, usb_root)
+        except OSError as exc:
+            # Une migration opportuniste ne doit jamais annuler la sélection
+            # d'une clé parfaitement inscriptible. C'est notamment fréquent
+            # avec les métadonnées POSIX sur FAT/exFAT/NTFS.
+            migration_error = exc
+            self._logger.warning(
+                "Stockage USB activé malgré une migration partielle de %s vers %s: %s",
+                previous_root,
+                usb_root,
+                exc,
+                extra={"error_code": "USB_MIGRATION_PARTIAL"},
+            )
         with self._lock:
             self._usb_root = usb_root
             self._mode = StorageMode.USB
+            if migration_error is None:
+                self._usb_diagnostic = f"Stockage USB actif: {usb_root}"
+            else:
+                self._usb_diagnostic = f"Stockage USB actif; migration partielle: {migration_error}"
         self._notify_callbacks(StorageMode.USB)
+
+    @classmethod
+    def _verify_usb_tree_writable(cls, usb_root: str) -> None:
+        for folder in ("", *cls._DYNAMIC_DIRS):
+            directory = usb_root if not folder else os.path.join(usb_root, folder)
+            probe = os.path.join(directory, ".clios-write-probe")
+            try:
+                with open(probe, "w", encoding="utf-8") as stream:
+                    stream.write("ok")
+            finally:
+                try:
+                    os.remove(probe)
+                except FileNotFoundError:
+                    pass
 
     def _switch_to_base_storage(self) -> None:
         mode = StorageMode.VOLATILE
@@ -414,15 +452,25 @@ class StorageManager:
                     continue
                 target = os.path.join(target_dir, filename)
                 if not os.path.exists(target):
-                    shutil.copy2(source, target)
+                    self._copy_file_portable(source, target)
                     report["copied"].append(os.path.relpath(target, target_root))
                     continue
                 if self._same_file_contents(source, target):
                     continue
                 conflict = self._conflict_path(target)
-                shutil.copy2(source, conflict)
+                self._copy_file_portable(source, conflict)
                 report["conflicts"].append(os.path.relpath(conflict, target_root))
         return report
+
+    @classmethod
+    def _copy_file_portable(cls, source: str, target: str) -> None:
+        """Accept a copy whose data succeeded but POSIX metadata was refused."""
+        try:
+            shutil.copy2(source, target)
+        except OSError:
+            if os.path.isfile(target) and cls._same_file_contents(source, target):
+                return
+            raise
 
     def migrate_existing_data(self, source_root: str, report_path: str | None = None) -> MigrationReport:
         """Copie une ancienne installation vers le stockage actif sans supprimer la source."""

--- a/tests/test_launcher_systemd.py
+++ b/tests/test_launcher_systemd.py
@@ -72,6 +72,14 @@ class LauncherSystemdTest(unittest.TestCase):
         self.assertIn("visudo -cf", installer)
         self.assertIn("sudo -n /usr/bin/raspi-config", helper)
 
+    def test_usb_mount_prepares_only_runtime_directories(self):
+        helper = (ROOT / "installation/usr/local/libexec/clios-usb-mount").read_text(encoding="utf-8")
+        self.assertIn("for managed_dir in dash_save logs trips trips_mock config diagnostics", helper)
+        self.assertIn('chmod 2775 "${clios_root}/${managed_dir}"', helper)
+        self.assertNotIn("chown -R", helper)
+        mounted_branch = helper.split('if [[ -n "$source" ]]', 1)[1].split("local clios_root", 1)[0]
+        self.assertNotIn("return 0", mounted_branch)
+
     def test_gui_hides_cursor_and_desktop_forces_mock_by_default(self):
         main = (ROOT / "main.py").read_text(encoding="utf-8")
         self.assertIn("--show-cursor", main)

--- a/tests/test_storage_manager.py
+++ b/tests/test_storage_manager.py
@@ -72,6 +72,44 @@ class StorageManagerTest(unittest.TestCase):
         self.assertEqual(self.manager.mode, StorageMode.USB)
         self.assertEqual(self.manager.get_status()["mount_point"], os.path.realpath(volume))
 
+    def test_nonempty_sda1_usb_wins_even_if_legacy_migration_fails(self):
+        pending = self.manager.resolve_path("logs/pending.log")
+        with open(pending, "w", encoding="utf-8") as stream:
+            stream.write("pending")
+        volume = os.path.join(self.media_root, "sda1")
+        usb_root = os.path.join(volume, "clios")
+        os.makedirs(os.path.join(usb_root, "export"))
+        with open(os.path.join(usb_root, "export", "ancien-export.zip"), "w", encoding="utf-8") as stream:
+            stream.write("keep")
+
+        with mock.patch("src.storage_manager.shutil.copy2", side_effect=PermissionError("metadata refused")):
+            self.assertTrue(self.manager.refresh())
+
+        self.assertEqual(self.manager.mode, StorageMode.USB)
+        self.assertEqual(self.manager.get_writable_root(), os.path.realpath(usb_root))
+        self.assertTrue(os.path.isfile(os.path.join(usb_root, "export", "ancien-export.zip")))
+        self.assertIn("migration partielle", self.manager.get_status()["usb_diagnostic"])
+
+    def test_metadata_error_after_successful_copy_does_not_fail_migration(self):
+        source = self.manager.resolve_path("logs/pending.log")
+        with open(source, "w", encoding="utf-8") as stream:
+            stream.write("complete data")
+        volume = os.path.join(self.media_root, "sda1")
+        usb_root = os.path.join(volume, "clios")
+        os.makedirs(usb_root)
+
+        def copy_then_reject_metadata(copy_source, copy_target):
+            shutil.copyfile(copy_source, copy_target)
+            raise PermissionError("chmod refused")
+
+        with mock.patch("src.storage_manager.shutil.copy2", side_effect=copy_then_reject_metadata):
+            self.assertTrue(self.manager.refresh())
+
+        self.assertEqual(self.manager.mode, StorageMode.USB)
+        with open(os.path.join(usb_root, "logs", "pending.log"), encoding="utf-8") as stream:
+            self.assertEqual(stream.read(), "complete data")
+        self.assertNotIn("migration partielle", self.manager.get_status()["usb_diagnostic"])
+
     def test_missing_linux_media_root_is_normal_on_desktop(self):
         missing_root = os.path.join(self.root, "does-not-exist")
         with mock.patch("src.storage_manager.logging.Logger.warning") as warning:


### PR DESCRIPTION
This pull request introduces several improvements and fixes around USB storage mounting, migration robustness, and user interface feedback. The main focus is to make USB storage handling more resilient to partial migration failures (especially due to POSIX metadata issues), to ensure only relevant runtime directories are prepared on mount, and to improve diagnostics and UI feedback for storage state.

**USB Storage Handling Improvements:**

- USB migration now tolerates partial failures (e.g., POSIX metadata errors): If copying files fails due to metadata issues but the data is successfully written, the migration proceeds and a diagnostic message indicates a partial migration instead of failing the USB activation. (`src/storage_manager.py`, `tests/test_storage_manager.py`) [[1]](diffhunk://#diff-96246a91e8437fb87040e3f87b882e0e5bd7b5314d2ccb5ca0afd7b6011415b7R373-R421) [[2]](diffhunk://#diff-96246a91e8437fb87040e3f87b882e0e5bd7b5314d2ccb5ca0afd7b6011415b7L417-R474) [[3]](diffhunk://#diff-3321dca7f38c5e6d5ebbc67d930090ffd2efd29c655d7f34540ec1dbba9e4236R75-R112)
- A new method `_copy_file_portable` is used during migration to allow data copies to succeed even if metadata cannot be set, further increasing robustness on filesystems like FAT/exFAT/NTFS. (`src/storage_manager.py`)

**USB Mount Script and Directory Preparation:**

- The USB mount script now only prepares specific runtime directories (`dash_save`, `logs`, `trips`, `trips_mock`, `config`, `diagnostics`) under `clios/` on the USB device, avoiding modifications to other contents or legacy exports. (`installation/usr/local/libexec/clios-usb-mount`, `tests/test_launcher_systemd.py`) [[1]](diffhunk://#diff-87df82c3f9665975fc7562fea45e53271d443024928f9f7e5d0ff5685bc55726R75-R88) [[2]](diffhunk://#diff-105f36f871ef70444c9d28de7f7dd6601947f3fe4dfadf436ae7a21884ad180bR75-R82)
- The script logic was refactored for clarity and to ensure the mount point is always created when needed. (`installation/usr/local/libexec/clios-usb-mount`)

**User Interface and Diagnostics:**

- The system page UI now displays more informative storage diagnostics by showing either the diagnostic message or storage mode, and improves text eliding and width for better readability. (`frontend/shared_pages/SystemPage.qml`)

**Testing Enhancements:**

- New tests cover USB migration scenarios, including partial migration due to metadata errors and ensuring that only runtime directories are prepared on mount. (`tests/test_storage_manager.py`, `tests/test_launcher_systemd.py`) [[1]](diffhunk://#diff-3321dca7f38c5e6d5ebbc67d930090ffd2efd29c655d7f34540ec1dbba9e4236R75-R112) [[2]](diffhunk://#diff-105f36f871ef70444c9d28de7f7dd6601947f3fe4dfadf436ae7a21884ad180bR75-R82)