### PR TITLE
perf(startup): reduce cold cockpit launch work

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -258,6 +258,13 @@ install_release_tree() {
         run_sudo_cmd "Nettoyage du staging incomplet" rm -rf "$staging_dir"
         return 1
     fi
+    if ! run_sudo_cmd "Précompilation Python pour le premier démarrage" \
+        "${staging_dir}/.venv/bin/python3" -m compileall -q \
+        "${staging_dir}/main.py" "${staging_dir}/src" "${staging_dir}/tools"; then
+        run_sudo_cmd "Restauration de l'environnement Python source" mv "${staging_dir}/.venv" "$VENV_DIR"
+        run_sudo_cmd "Nettoyage du staging incomplet" rm -rf "$staging_dir"
+        return 1
+    fi
     if [[ -f "${staging_dir}/tools/qml_smoke.py" ]] && ! run_target_cmd "Self-check QML de la release" \
         env QT_QPA_PLATFORM=offscreen "${staging_dir}/.venv/bin/python3" "${staging_dir}/tools/qml_smoke.py"; then
         run_sudo_cmd "Restauration de l'environnement Python source" mv "${staging_dir}/.venv" "$VENV_DIR"

--- a/installation/systemd/clios.service.in
+++ b/installation/systemd/clios.service.in
@@ -1,7 +1,6 @@
 [Unit]
 Description=CliOS Automotive Dashboard (Wayland Kiosk via Cage)
-After=sound.target can0.service systemd-user-sessions.service
-Wants=can0.service
+After=systemd-user-sessions.service
 
 [Service]
 Type=simple

--- a/src/release_manager.py
+++ b/src/release_manager.py
@@ -135,6 +135,7 @@ class ReleaseManager:
             self._progress("DOWNLOADING", 100, "Installation de l'environnement")
             self._install_environment(release_root, str(manifest.get("platform", "")))
             self.self_check(release_root, run_as=self.self_check_user)
+            self._precompile_runtime(release_root)
             os.replace(release_root, target)
             self._write_json_atomic(target / "release-manifest.json", manifest)
             self._progress("STAGED", 100, f"Release {version} préparée")
@@ -331,6 +332,19 @@ class ReleaseManager:
             )
             if result.returncode:
                 raise ReleaseError("self-check QML: " + (result.stderr or result.stdout))
+
+    @staticmethod
+    def _precompile_runtime(release_root: Path) -> None:
+        """Persist target-version bytecode so the first cockpit boot stays light."""
+        python = release_root / ".venv/bin/python3"
+        if not python.exists():
+            return
+        result = subprocess.run(
+            [str(python), "-m", "compileall", "-q", "main.py", "src", "tools"],
+            cwd=release_root, capture_output=True, text=True, timeout=120,
+        )
+        if result.returncode:
+            raise ReleaseError("précompilation Python: " + (result.stderr or result.stdout))
 
     @staticmethod
     def _install_environment(release_root: Path, platform_id: str = "") -> None:

--- a/src/services/cabin_noise_service.py
+++ b/src/services/cabin_noise_service.py
@@ -1,7 +1,5 @@
 import time
 import threading
-import numpy as np
-import sounddevice as sd
 from src.services.base_service import BaseService
 from src.services.param_types import ServiceParamType
 
@@ -13,6 +11,8 @@ class CabinNoiseService(BaseService):
         super().__init__("Noise", storage)
         self.runtime = runtime
         self._stream = None
+        self._np = None
+        self._sd = None
 
         self._last_fft_time = 0
 
@@ -36,6 +36,9 @@ class CabinNoiseService(BaseService):
         self._thread.start()
 
     def _audio_callback(self, indata, frames, time_info, status):
+        np = self._np
+        if np is None:
+            return
         audio_data = indata[:, 0]
         rms = np.sqrt(np.mean(audio_data ** 2))
 
@@ -77,7 +80,14 @@ class CabinNoiseService(BaseService):
 
     def _run(self, stop_event):
         try:
-            self._stream = sd.InputStream(callback=self._audio_callback, channels=1, samplerate=44100)
+            # NumPy et PortAudio sont coûteux sur un cache froid Raspberry Pi.
+            # Les charger dans le worker laisse Qt afficher sa première image
+            # avant l'initialisation facultative du microphone.
+            import numpy as np
+            import sounddevice as sd
+            self._np = np
+            self._sd = sd
+            self._stream = self._sd.InputStream(callback=self._audio_callback, channels=1, samplerate=44100)
             self._stream.start()
             self.set_ok("Microphone actif")
 

--- a/tests/test_launcher_systemd.py
+++ b/tests/test_launcher_systemd.py
@@ -32,6 +32,8 @@ class LauncherSystemdTest(unittest.TestCase):
         self.assertIn("Environment=CLIOS_HIDE_CURSOR=1", rendered)
         self.assertIn("@USER@", template)
         self.assertFalse((ROOT / "installation/etc/systemd/system/clios.service").exists())
+        self.assertNotIn("can0.service", rendered)
+        self.assertNotIn("sound.target", rendered)
 
     def test_installer_has_offline_targets_for_both_supported_distributions(self):
         installer = (ROOT / "install.sh").read_text(encoding="utf-8")
@@ -45,6 +47,8 @@ class LauncherSystemdTest(unittest.TestCase):
         self.assertIn("--exclude='./.venv'", installer)
         self.assertIn('mv "$VENV_DIR" "${staging_dir}/.venv"', installer)
         self.assertIn("Self-check QML de la release", installer)
+        self.assertIn("Précompilation Python pour le premier démarrage", installer)
+        self.assertIn("-m compileall -q", installer)
         self.assertNotIn('cp -a "${PROJECT_DIR}/." "${RELEASE_DIR}/"', installer)
         self.assertLess(
             installer.index('install_release_tree "$RELEASE_DIR"'),

--- a/tests/test_release_manager.py
+++ b/tests/test_release_manager.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import os
+import subprocess
 import tarfile
 import tempfile
 import unittest
@@ -101,6 +102,18 @@ class ReleaseManagerTest(unittest.TestCase):
                 mock.patch("pwd.getpwnam", return_value=account):
             options = self.manager._run_as_options("clios")
         self.assertEqual(set(options), {"user", "group"})
+
+    def test_runtime_precompile_uses_the_release_python(self):
+        release = self.root / "release"
+        python = release / ".venv/bin/python3"
+        python.parent.mkdir(parents=True)
+        python.touch()
+        completed = subprocess.CompletedProcess([], 0, "", "")
+        with mock.patch("src.release_manager.subprocess.run", return_value=completed) as run:
+            self.manager._precompile_runtime(release)
+
+        self.assertEqual(run.call_args.args[0][:4], [str(python), "-m", "compileall", "-q"])
+        self.assertEqual(run.call_args.kwargs["cwd"], release)
 
     def test_channel_is_stable_by_default_and_persists(self):
         self.assertEqual(self.manager.get_channel(), "stable")

--- a/tests/test_startup_performance_contract.py
+++ b/tests/test_startup_performance_contract.py
@@ -1,0 +1,20 @@
+import subprocess
+import sys
+import unittest
+
+
+class StartupPerformanceContractTest(unittest.TestCase):
+    def test_cabin_noise_module_defers_heavy_audio_imports(self):
+        script = (
+            "import sys; import src.services.cabin_noise_service; "
+            "assert 'numpy' not in sys.modules; "
+            "assert 'sounddevice' not in sys.modules"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script], capture_output=True, text=True, timeout=10,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request introduces optimizations for startup performance and reliability, focusing on deferring heavy audio module imports, adding Python bytecode precompilation to speed up first boot, and improving systemd service configuration. It also adds new and updated tests to ensure these behaviors.

**Startup performance improvements:**
* Deferred the imports of `numpy` and `sounddevice` in `cabin_noise_service.py` so they are only loaded in the worker thread, reducing initial startup time and memory usage. [[1]](diffhunk://#diff-db72d8947b8b8861bab7d8128c4b2af22efb0b28a4b0e0fc1fb8b6605a2c6ebaL3-L4) [[2]](diffhunk://#diff-db72d8947b8b8861bab7d8128c4b2af22efb0b28a4b0e0fc1fb8b6605a2c6ebaR14-R15) [[3]](diffhunk://#diff-db72d8947b8b8861bab7d8128c4b2af22efb0b28a4b0e0fc1fb8b6605a2c6ebaL80-R90) [[4]](diffhunk://#diff-db72d8947b8b8861bab7d8128c4b2af22efb0b28a4b0e0fc1fb8b6605a2c6ebaR39-R41)
* Added a new test to verify that the cabin noise service does not import heavy audio modules at startup (`tests/test_startup_performance_contract.py`).

**Python runtime precompilation:**
* Added a precompilation step for Python bytecode during release installation to keep the first cockpit boot fast, implemented in both the shell installer (`install.sh`) and the Python release manager (`src/release_manager.py`). [[1]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fR261-R267) [[2]](diffhunk://#diff-514d5147b80b78b9fdc0d1a2264855918ab1bf00dbcad985e5f7c301c98331b8R138) [[3]](diffhunk://#diff-514d5147b80b78b9fdc0d1a2264855918ab1bf00dbcad985e5f7c301c98331b8R336-R348)
* Added a test to verify that precompilation uses the correct Python interpreter from the release environment.

**Systemd service configuration:**
* Updated the `clios.service` systemd unit template to remove dependencies on `sound.target` and `can0.service`, simplifying the service startup order.
* Updated tests to ensure these dependencies are no longer present in the rendered systemd unit.

**Installer and test improvements:**
* Updated installer tests to check for the presence of the new precompilation step and related command-line arguments.
* Minor test and import fixes to support the above changes.

These changes collectively improve the reliability and performance of the installation and startup process, while ensuring that tests cover new behaviors and optimizations.