### PR TITLE
fix(trips): persist sessions across power cycles

### DIFF
--- a/frontend/components/AppShell.qml
+++ b/frontend/components/AppShell.qml
@@ -119,6 +119,15 @@ Item {
         }
     }
 
+    C.TripRecoveryDialog {
+        z: 9350
+        available: S.UiState.tripResumeAvailable
+        secondsRemaining: S.UiState.tripResumeSeconds
+        tripSummary: S.UiState.resumableTrip
+        onResumeRequested: bridge.executeUiCommand("resume_trip", S.UiState.speed)
+        onNewTripRequested: bridge.executeUiCommand("new_trip", S.UiState.speed)
+    }
+
     NotificationCenter { z: 9400 }
     Timer {
         interval: 500; running: !root.recoveryOpened; repeat: true

--- a/frontend/shared_pages/components/TripRecoveryDialog.qml
+++ b/frontend/shared_pages/components/TripRecoveryDialog.qml
@@ -1,0 +1,119 @@
+import QtQuick
+import QtQuick.Layouts
+import "../../style" as T
+
+Rectangle {
+    id: root
+    objectName: "tripRecoveryDialog"
+    signal resumeRequested()
+    signal newTripRequested()
+
+    property bool available: false
+    property int secondsRemaining: 0
+    property var tripSummary: ({})
+
+    visible: available
+    anchors.fill: parent
+    color: Qt.rgba(0.02, 0.03, 0.04, 0.97)
+
+    function fixed(value, decimals) {
+        const numeric = Number(value)
+        return isNaN(numeric) ? "0" : numeric.toFixed(decimals).replace(".", ",")
+    }
+
+    function formattedDate(value) {
+        const date = new Date(value || "")
+        return isNaN(date.getTime()) ? "" : Qt.formatDateTime(date, "dd/MM/yyyy à hh:mm")
+    }
+
+    Rectangle {
+        anchors.centerIn: parent
+        width: 860
+        height: 430
+        radius: T.StyleManager.radiusLarge
+        color: T.StyleManager.surface
+        border.width: 2
+        border.color: T.StyleManager.accent
+
+        ColumnLayout {
+            anchors.fill: parent
+            anchors.margins: 38
+            spacing: 22
+
+            Text {
+                Layout.fillWidth: true
+                text: "CONTINUER LE TRAJET PRÉCÉDENT ?"
+                color: T.StyleManager.text
+                font.family: T.StyleManager.fontFamily
+                font.pixelSize: 31
+                font.weight: Font.DemiBold
+                horizontalAlignment: Text.AlignHCenter
+            }
+
+            Text {
+                Layout.fillWidth: true
+                text: "Le dernier trajet a été conservé lors de l’extinction."
+                      + (root.formattedDate(root.tripSummary.date) !== ""
+                         ? "\nDernier arrêt : " + root.formattedDate(root.tripSummary.date) : "")
+                color: T.StyleManager.textSecondary
+                font.family: T.StyleManager.fontFamily
+                font.pixelSize: 19
+                horizontalAlignment: Text.AlignHCenter
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                Layout.preferredHeight: 100
+                spacing: 18
+
+                Item {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    Column {
+                        anchors.centerIn: parent
+                        spacing: 7
+                        Text { anchors.horizontalCenter: parent.horizontalCenter; text: "DISTANCE"; color: T.StyleManager.textSecondary; font.pixelSize: 13; font.bold: true }
+                        Text { anchors.horizontalCenter: parent.horizontalCenter; text: root.fixed(root.tripSummary.distance_km, 1) + " km"; color: T.StyleManager.text; font.pixelSize: 30; font.bold: true }
+                    }
+                }
+                Rectangle { width: 1; Layout.fillHeight: true; color: T.StyleManager.outline }
+                Item {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    Column {
+                        anchors.centerIn: parent
+                        spacing: 7
+                        Text { anchors.horizontalCenter: parent.horizontalCenter; text: "COÛT ESTIMÉ"; color: T.StyleManager.textSecondary; font.pixelSize: 13; font.bold: true }
+                        Text { anchors.horizontalCenter: parent.horizontalCenter; text: root.fixed(root.tripSummary.cost_eur, 2) + " €"; color: T.StyleManager.text; font.pixelSize: 30; font.bold: true }
+                    }
+                }
+            }
+
+            Text {
+                Layout.fillWidth: true
+                text: "Nouveau trajet automatique dans " + root.secondsRemaining + " s"
+                color: T.StyleManager.warning
+                font.family: T.StyleManager.fontFamily
+                font.pixelSize: 17
+                font.weight: Font.Bold
+                horizontalAlignment: Text.AlignHCenter
+            }
+
+            RowLayout {
+                Layout.alignment: Qt.AlignHCenter
+                spacing: 18
+                Button {
+                    Layout.preferredWidth: 300
+                    text: "NOUVEAU TRAJET"
+                    onClicked: root.newTripRequested()
+                }
+                Button {
+                    Layout.preferredWidth: 350
+                    text: "CONTINUER LE TRAJET"
+                    primary: true
+                    onClicked: root.resumeRequested()
+                }
+            }
+        }
+    }
+}

--- a/frontend/state/UiState.qml
+++ b/frontend/state/UiState.qml
@@ -133,6 +133,9 @@ QtObject {
     property real fuelLevel: rawFuelLevel
     readonly property real odometer: number(motion.odometer, 0)
     readonly property string sessionState: text(sessionRuntimeState.state, "IDLE")
+    readonly property bool tripResumeAvailable: sessionRuntimeState.resume_available === true
+    readonly property int tripResumeSeconds: intValue(sessionRuntimeState.resume_seconds, 0)
+    readonly property var resumableTrip: sessionRuntimeState.resume_trip || ({})
 
     // Pédales & Couple
     property real throttle: rawThrottle

--- a/frontend/styles/apex/pages/ApexDrivePage.qml
+++ b/frontend/styles/apex/pages/ApexDrivePage.qml
@@ -162,14 +162,14 @@ Item {
                             width: stateText.implicitWidth + 22
                             height: 34
                             radius: 17
-                            color: S.UiState.sessionState === "PAUSED" ? "#2F2310" : "#10281F"
+                            color: S.UiState.sessionState === "PAUSED" || S.UiState.sessionState === "SUSPENDED" ? "#2F2310" : "#10281F"
                             border.width: 1
-                            border.color: S.UiState.sessionState === "PAUSED" ? "#FFB84D" : "#54E3A5"
+                            border.color: S.UiState.sessionState === "PAUSED" || S.UiState.sessionState === "SUSPENDED" ? "#FFB84D" : "#54E3A5"
                             Text {
                                 id: stateText
                                 anchors.centerIn: parent
-                                text: S.UiState.sessionState === "PAUSED" ? "EN PAUSE" : "ACTIVE"
-                                color: S.UiState.sessionState === "PAUSED" ? "#FFD17D" : "#69EDB2"
+                                text: S.UiState.sessionState === "SUSPENDED" ? "SAUVEGARDÉ" : (S.UiState.sessionState === "PAUSED" ? "EN PAUSE" : "ACTIVE")
+                                color: S.UiState.sessionState === "PAUSED" || S.UiState.sessionState === "SUSPENDED" ? "#FFD17D" : "#69EDB2"
                                 font.pixelSize: 12
                                 font.bold: true
                                 font.letterSpacing: 1.3
@@ -182,6 +182,7 @@ Item {
                         spacing: 12
                         ApexMetric { Layout.fillWidth: true; label: "TRIP A"; value: S.UiState.fixed(S.UiState.tripA, 1, "0,0"); unit: "km"; valueSize: 24 }
                         ApexMetric { Layout.fillWidth: true; label: "TRIP B"; value: S.UiState.fixed(S.UiState.tripB, 1, "0,0"); unit: "km"; valueSize: 24 }
+                        ApexMetric { Layout.fillWidth: true; label: "COÛT EST."; value: S.UiState.fixed(S.UiState.tripCost, 2, "0,00"); unit: "€"; valueSize: 24 }
                     }
 
                     Item { Layout.fillHeight: true }
@@ -199,7 +200,7 @@ Item {
                             spacing: 12
                             Rectangle { width: 10; height: 10; radius: 5; color: T.StyleManager.accent; anchors.verticalCenter: parent.verticalCenter }
                             Text {
-                                text: S.UiState.sessionState === "PAUSED" ? "REPRENDRE LE TRAJET" : "TERMINER LE TRAJET"
+                                text: S.UiState.sessionState === "SUSPENDED" ? "EXTINCTION EN COURS" : (S.UiState.sessionState === "PAUSED" ? "REPRENDRE LE TRAJET" : "TERMINER LE TRAJET")
                                 color: "#FFFFFF"
                                 font.pixelSize: 15
                                 font.bold: true
@@ -209,6 +210,7 @@ Item {
                         MouseArea {
                             id: sessionTouch
                             anchors.fill: parent
+                            enabled: S.UiState.sessionState === "RUNNING" || S.UiState.sessionState === "PAUSED"
                             onClicked: {
                                 if (S.UiState.sessionState === "PAUSED") root.actionRequested("resume_trip")
                                 else root.actionRequested("end_trip")

--- a/src/bridge/ui_command_router.py
+++ b/src/bridge/ui_command_router.py
@@ -21,6 +21,8 @@ class UiCommandRouter:
             "reset_maintenance": self.target.resetMaintenance,
             "end_trip": self.target.endTripSession,
             "resume_trip": self.target.resumeTripSession,
+            "new_trip": lambda: self.target.session_manager.start_new_trip()
+            if self.target.session_manager else False,
             "pause_trip": lambda: self.target.setSessionState("PAUSED"),
             "quit": self.target.quitApplication,
             "restart": self.target.restartApplication,

--- a/src/services/trip_session_manager.py
+++ b/src/services/trip_session_manager.py
@@ -1,73 +1,157 @@
 import json
 import os
-import time
 import threading
+import time
 from datetime import datetime
+
 from src.services.base_service import BaseService
 
 
 class TripSessionManager(BaseService):
-    VALID_STATES = {"IDLE", "RUNNING", "PAUSED", "WAITING_IGNITION", "ENDING", "ENDED"}
+    VALID_STATES = {
+        "IDLE", "RUNNING", "PAUSED", "WAITING_IGNITION", "SUSPENDED",
+        "RECOVERY_PENDING", "ENDING", "ENDED",
+    }
+    CHECKPOINT_SCHEMA_VERSION = 1
+    # Deliberately not suffixed .json: ExportService scans JSON files and must
+    # never copy or delete an active checkpoint.
+    CHECKPOINT_FILENAME = ".active_trip.checkpoint"
+    CHECKPOINT_INTERVAL_S = 5.0
+    RECOVERY_TIMEOUT_S = 30.0
 
     def __init__(self, runtime, storage, stats_service, trips_dir):
         super().__init__("SessionManager", storage)
         self.runtime = runtime
         self.stats_service = stats_service
-
         self.trips_dir = trips_dir
         self._dir_lock = threading.RLock()
-        self._pending_summaries = []
         self._session_lock = threading.RLock()
+        self._pending_summaries = []
+        self._recovery_checkpoint = None
+        self._recovery_deadline = None
         self._ensure_trips_dir()
-
-        # Initialise explicitement l'état de session.
-        self.runtime.publish("session", {"state": "IDLE"}, source="session-manager")
 
         self.trip_start_time = None
         self.trip_start_odo = 0.0
         self.trip_trace = []
         self.last_trace_time = 0.0
+        self.last_checkpoint_time = 0.0
 
-    # Commandes exposées à l'interface.
+        self._recovery_checkpoint = self._load_checkpoint()
+        if self._recovery_checkpoint is not None:
+            self._publish_session("RECOVERY_PENDING", self.RECOVERY_TIMEOUT_S)
+        else:
+            self._publish_session("IDLE")
+
     def resume_trip(self):
-        if self.runtime.snapshot().domain("session").get("state") == "PAUSED":
-            self.runtime.publish(
-                "session", {"state": "WAITING_IGNITION"}, source="session-manager"
-            )
-            self.set_ok("Trajet repris, en attente de contact...")
+        with self._session_lock:
+            snapshot = self.runtime.snapshot()
+            state = snapshot.domain("session").get("state")
+            if state == "RECOVERY_PENDING" and self._recovery_checkpoint is not None:
+                checkpoint = self._recovery_checkpoint
+                try:
+                    self.stats_service.restore_session_checkpoint(checkpoint["stats_state"])
+                    self.trip_start_time = float(checkpoint["metadata"]["started_at"])
+                    self.trip_start_odo = float(checkpoint["metadata"]["start_odo_km"])
+                    self.trip_trace = list(checkpoint.get("trace", []))
+                except (KeyError, RuntimeError, TypeError, ValueError) as exc:
+                    self.set_error(f"Reprise du trajet impossible : {exc}")
+                    return False
+
+                self._recovery_deadline = None
+                ignition = bool(snapshot.domain("powertrain").get("key_run", False))
+                self._publish_session("RUNNING" if ignition else "WAITING_IGNITION")
+                self.last_checkpoint_time = time.monotonic()
+                self.set_ok("Trajet précédent repris")
+                return True
+
+            if state == "PAUSED":
+                self._publish_session("WAITING_IGNITION")
+                self.set_ok("Trajet repris, en attente de contact...")
+                return True
+        return False
+
+    def start_new_trip(self):
+        """Archive the recoverable trip before starting a clean session."""
+        with self._session_lock:
+            state = self.runtime.snapshot().domain("session").get("state")
+            if state != "RECOVERY_PENDING" or self._recovery_checkpoint is None:
+                return False
+            if not self._archive_recovery_checkpoint():
+                self._publish_session("RECOVERY_PENDING", 0)
+                self.set_warning("Impossible d'archiver l'ancien trajet; nouvelle tentative en cours")
+                return False
+
+            self._recovery_deadline = None
+            self._recovery_checkpoint = None
+            self._publish_session("IDLE")
+            snapshot = self.runtime.snapshot()
+            if bool(snapshot.domain("powertrain").get("key_run", False)):
+                self._begin_new_session(snapshot)
+            return True
 
     def end_trip(self):
         with self._session_lock:
             snapshot = self.runtime.snapshot()
             state = snapshot.domain("session").get("state")
-            if state not in ["RUNNING", "PAUSED", "WAITING_IGNITION"]:
-                return
-            # Fige d'abord la session afin que TripStats ne continue pas à
-            # alimenter les compteurs pendant la sérialisation.
-            self.runtime.publish(
-                "session", {"state": "ENDING"}, source="session-manager"
-            )
+            if state not in ["RUNNING", "PAUSED", "WAITING_IGNITION", "SUSPENDED"]:
+                return False
+            self._publish_session("ENDING")
             current_odo = snapshot.domain("motion").get("odometer", 0.0)
             final_stats = self.stats_service.finish_session(current_odo)
             saved = self._save_trip_summary(final_stats, current_odo)
-            self.runtime.publish("session", {"state": "IDLE"}, source="session-manager")
+            self._publish_session("IDLE")
             self.trip_start_time = None
             self.trip_trace.clear()
             if saved:
+                self._remove_checkpoint()
+                self._recovery_checkpoint = None
                 self.set_ok("Trajet sauvegardé")
             else:
                 self.set_warning("Trajet conservé en mémoire, écriture en attente")
+            return saved
 
-    # Persistance de la synthèse de trajet.
-    def _save_trip_summary(self, stats, end_odo):
-        end_time = time.time()
+    def _publish_session(self, state, recovery_seconds=None):
+        summary = {}
+        if state == "RECOVERY_PENDING" and self._recovery_checkpoint is not None:
+            checkpoint = self._recovery_checkpoint
+            stats = checkpoint.get("stats_state", {}).get("stats", {})
+            metadata = checkpoint.get("metadata", {})
+            summary = {
+                "date": metadata.get("suspended_at_iso", ""),
+                "distance_km": stats.get("distance_km", 0.0),
+                "cost_eur": stats.get("session_cost", 0.0),
+            }
+        self.runtime.publish(
+            "session",
+            {
+                "state": state,
+                "resume_available": state == "RECOVERY_PENDING",
+                "resume_seconds": recovery_seconds,
+                "resume_trip": summary,
+            },
+            source="session-manager",
+        )
 
+    def _begin_new_session(self, snapshot):
+        current_odo = snapshot.domain("motion").get("odometer", 0.0)
+        self.stats_service.begin_session(current_odo)
+        self.trip_start_time = time.time()
+        self.trip_start_odo = current_odo
+        self.trip_trace = []
+        self.last_trace_time = 0.0
+        self._publish_session("RUNNING")
+        self._write_checkpoint(current_odo)
+        self.last_checkpoint_time = time.monotonic()
+        self.set_ok("Enregistrement en cours")
+
+    def _build_trip_summary(self, stats, end_odo, *, ended_at=None):
+        end_time = time.time() if ended_at is None else float(ended_at)
         duration_sec = int(end_time - self.trip_start_time) if self.trip_start_time else 0
-
-        trip_summary = {
+        return {
             "metadata": {
-                "date": datetime.now().isoformat(),
-                "duration_sec": duration_sec,
+                "date": datetime.fromtimestamp(end_time).isoformat(),
+                "duration_sec": max(0, duration_sec),
                 "start_odo_km": self.trip_start_odo,
                 "end_odo_km": end_odo,
             },
@@ -82,9 +166,11 @@ class TripSessionManager(BaseService):
                 ),
                 "longitudinal_g_last": stats.get("longitudinal_g", 0.0),
             },
-            "trace": list(self.trip_trace)
+            "trace": list(self.trip_trace),
         }
 
+    def _save_trip_summary(self, stats, end_odo):
+        trip_summary = self._build_trip_summary(stats, end_odo)
         if self._write_summary(trip_summary):
             return True
         with self._dir_lock:
@@ -95,27 +181,125 @@ class TripSessionManager(BaseService):
         timestamp_str = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
         filename = f"trip_{timestamp_str}.json"
         with self._dir_lock:
-            trips_dir = self.trips_dir
-        filepath = os.path.join(trips_dir, filename)
-        tmp_path = filepath + ".tmp"
-
+            filepath = os.path.join(self.trips_dir, filename)
         try:
-            os.makedirs(trips_dir, exist_ok=True)
-            with open(tmp_path, 'w', encoding='utf-8') as f:
-                json.dump(trip_summary, f, indent=4)
-                f.flush()
-                os.fsync(f.fileno())
-            os.replace(tmp_path, filepath)
+            self._write_json_atomic(filepath, trip_summary)
             self.print_message(f"Trajet exporté : {filename}")
             return True
-        except Exception as exc:
+        except (OSError, TypeError, ValueError) as exc:
+            self.set_warning(f"Écriture du trajet différée : {exc}")
+            return False
+
+    @staticmethod
+    def _write_json_atomic(filepath, payload):
+        os.makedirs(os.path.dirname(filepath), exist_ok=True)
+        tmp_path = filepath + ".tmp"
+        try:
+            with open(tmp_path, "w", encoding="utf-8") as stream:
+                json.dump(payload, stream, indent=4)
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(tmp_path, filepath)
+        except Exception:
             try:
                 if os.path.exists(tmp_path):
                     os.remove(tmp_path)
             except OSError:
                 pass
-            self.set_warning(f"Écriture du trajet différée : {exc}")
+            raise
+
+    def _checkpoint_path(self, trips_dir=None):
+        return os.path.join(trips_dir or self.trips_dir, self.CHECKPOINT_FILENAME)
+
+    def _make_checkpoint(self, end_odo):
+        now = time.time()
+        return {
+            "schema_version": self.CHECKPOINT_SCHEMA_VERSION,
+            "metadata": {
+                "started_at": self.trip_start_time or now,
+                "start_odo_km": self.trip_start_odo,
+                "end_odo_km": end_odo,
+                "suspended_at": now,
+                "suspended_at_iso": datetime.fromtimestamp(now).isoformat(),
+            },
+            "stats_state": self.stats_service.export_session_checkpoint(),
+            "trace": list(self.trip_trace),
+        }
+
+    def _write_checkpoint(self, end_odo):
+        try:
+            checkpoint = self._make_checkpoint(end_odo)
+            with self._dir_lock:
+                self._write_json_atomic(self._checkpoint_path(), checkpoint)
+            self._recovery_checkpoint = checkpoint
+            return True
+        except (OSError, RuntimeError, TypeError, ValueError) as exc:
+            self.set_warning(f"Checkpoint du trajet impossible : {exc}")
             return False
+
+    def _load_checkpoint(self):
+        filepath = self._checkpoint_path()
+        if not os.path.isfile(filepath):
+            return None
+        try:
+            with open(filepath, encoding="utf-8") as stream:
+                checkpoint = json.load(stream)
+            required_stats_state = {
+                "stats", "start_odo", "session_distance_km", "absolute_fuel_session",
+                "rpm_integral", "engine_time", "aggressive_time", "motion_time",
+                "deceleration_without_throttle_dist", "shift_time_sum", "shift_count",
+            }
+            if (
+                not isinstance(checkpoint, dict)
+                or checkpoint.get("schema_version") != self.CHECKPOINT_SCHEMA_VERSION
+                or not isinstance(checkpoint.get("metadata"), dict)
+                or not isinstance(checkpoint.get("stats_state"), dict)
+                or not required_stats_state.issubset(checkpoint["stats_state"])
+                or not isinstance(checkpoint["stats_state"].get("stats"), dict)
+                or "started_at" not in checkpoint["metadata"]
+                or "start_odo_km" not in checkpoint["metadata"]
+            ):
+                raise ValueError("format incomplet")
+            return checkpoint
+        except (OSError, json.JSONDecodeError, TypeError, ValueError) as exc:
+            invalid_path = f"{filepath}.invalid.{int(time.time())}"
+            try:
+                os.replace(filepath, invalid_path)
+            except OSError:
+                pass
+            self.set_warning(f"Checkpoint de trajet isolé : {exc}")
+            return None
+
+    def _archive_recovery_checkpoint(self):
+        checkpoint = self._recovery_checkpoint
+        if checkpoint is None:
+            return True
+        metadata = checkpoint["metadata"]
+        stats = checkpoint["stats_state"].get("stats", {})
+        previous = (self.trip_start_time, self.trip_start_odo, self.trip_trace)
+        self.trip_start_time = float(metadata["started_at"])
+        self.trip_start_odo = float(metadata["start_odo_km"])
+        self.trip_trace = list(checkpoint.get("trace", []))
+        try:
+            summary = self._build_trip_summary(
+                stats,
+                metadata.get("end_odo_km", self.trip_start_odo),
+                ended_at=metadata.get("suspended_at", time.time()),
+            )
+            if not self._write_summary(summary):
+                return False
+            self._remove_checkpoint()
+            return True
+        finally:
+            self.trip_start_time, self.trip_start_odo, self.trip_trace = previous
+
+    def _remove_checkpoint(self, trips_dir=None):
+        try:
+            os.remove(self._checkpoint_path(trips_dir))
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            self.set_warning(f"Nettoyage du checkpoint impossible : {exc}")
 
     def _ensure_trips_dir(self):
         try:
@@ -126,11 +310,21 @@ class TripSessionManager(BaseService):
             return False
 
     def update_trips_dir(self, new_dir: str):
-        """Change la cible à chaud et retente les trajets gardés en RAM."""
+        """Change la cible à chaud et conserve le checkpoint actif."""
         with self._dir_lock:
+            old_dir = self.trips_dir
             self.trips_dir = new_dir
         if not self._ensure_trips_dir():
             return False
+
+        if self._recovery_checkpoint is not None:
+            try:
+                self._write_json_atomic(self._checkpoint_path(), self._recovery_checkpoint)
+                if os.path.abspath(old_dir) != os.path.abspath(new_dir):
+                    self._remove_checkpoint(old_dir)
+            except (OSError, TypeError, ValueError) as exc:
+                self.set_warning(f"Déplacement du checkpoint impossible : {exc}")
+                return False
 
         with self._dir_lock:
             pending = list(self._pending_summaries)
@@ -145,17 +339,32 @@ class TripSessionManager(BaseService):
             return False
         return True
 
-    # Cycle de vie du service.
+    def _suspend_trip(self, snapshot):
+        if snapshot.domain("session").get("state") == "RUNNING":
+            self._publish_session("SUSPENDED")
+        current_odo = snapshot.domain("motion").get("odometer", 0.0)
+        saved = self._write_checkpoint(current_odo)
+        if saved:
+            self.set_warning("Trajet conservé; reprise proposée au prochain démarrage")
+        return saved
+
     def stop(self):
         super().stop()
-        state = self.runtime.snapshot().domain("session").get("state")
-        if state in ["RUNNING", "PAUSED", "WAITING_IGNITION"]:
-            self.print_message("Arrêt système détecté : Sauvegarde automatique du trajet.")
-            self.end_trip()
+        with self._session_lock:
+            snapshot = self.runtime.snapshot()
+            state = snapshot.domain("session").get("state")
+            if state in ["RUNNING", "PAUSED", "WAITING_IGNITION", "SUSPENDED"]:
+                self.print_message("Arrêt système détecté : checkpoint du trajet en cours.")
+                self._suspend_trip(snapshot)
 
     def start(self, stop_event: threading.Event):
         super().start(stop_event, implemented=True)
-        self._thread = threading.Thread(target=self._run, args=(stop_event,), daemon=True, name=self.service_name)
+        if self._recovery_checkpoint is not None:
+            self._recovery_deadline = time.monotonic() + self.RECOVERY_TIMEOUT_S
+            self._publish_session("RECOVERY_PENDING", self.RECOVERY_TIMEOUT_S)
+        self._thread = threading.Thread(
+            target=self._run, args=(stop_event,), daemon=True, name=self.service_name
+        )
         self._thread.start()
 
     def _run(self, stop_event: threading.Event):
@@ -163,48 +372,41 @@ class TripSessionManager(BaseService):
             snapshot = self.runtime.snapshot()
             powertrain = snapshot.domain("powertrain")
             motion = snapshot.domain("motion")
-            session = snapshot.domain("session")
-            ignition = powertrain.get("key_run", False)
-            state = session.get("state")
-            current_time = time.time()
+            state = snapshot.domain("session").get("state")
+            ignition = bool(powertrain.get("key_run", False))
+            wall_time = time.time()
+            monotonic_time = time.monotonic()
             current_speed = motion.get("speed", 0.0)
 
-            # Démarre une nouvelle session.
-            if ignition and state in ["IDLE", "ENDED"]:
-                current_odo = motion.get("odometer", 0.0)
-                self.stats_service.begin_session(current_odo)
-                self.runtime.publish("session", {"state": "RUNNING"}, source="session-manager")
-                self.trip_start_time = current_time
-                self.trip_start_odo = current_odo
-                self.trip_trace = []
-                self.set_ok("Enregistrement en cours")
-
-            # Reprise manuelle après pause.
-            elif state == "WAITING_IGNITION" and (ignition or current_speed > 3.0):
-                self.runtime.publish("session", {"state": "RUNNING"}, source="session-manager")
+            if state == "RECOVERY_PENDING" and self._recovery_deadline is not None:
+                remaining = max(0, int(self._recovery_deadline - monotonic_time + 0.999))
+                self._publish_session("RECOVERY_PENDING", remaining)
+                if remaining == 0:
+                    self.start_new_trip()
+            elif ignition and state in ["IDLE", "ENDED"]:
+                with self._session_lock:
+                    self._begin_new_session(snapshot)
+            elif state in ["WAITING_IGNITION", "SUSPENDED"] and (ignition or current_speed > 3.0):
+                self._publish_session("RUNNING")
                 self.set_ok("Reprise de l'enregistrement")
-
-            # Reprise automatique sur mouvement véhicule.
             elif state == "PAUSED" and current_speed > 3.0:
-                self.runtime.publish("session", {"state": "RUNNING"}, source="session-manager")
-                self.set_ok("Reprise automatique (mouvement detecte)")
-
-            # Mise en pause automatique sans contact.
+                self._publish_session("RUNNING")
+                self.set_ok("Reprise automatique (mouvement détecté)")
             elif not ignition and state == "RUNNING":
-                self.runtime.publish("session", {"state": "PAUSED"}, source="session-manager")
-                self.set_warning("En attente de décision...")
-
-            # Enregistre la trace de session.
+                with self._session_lock:
+                    self._suspend_trip(snapshot)
             elif state == "RUNNING":
-                if current_time - self.last_trace_time >= 5.0:
+                if wall_time - self.last_trace_time >= self.CHECKPOINT_INTERVAL_S:
                     point = {
-                        "ts": int(current_time),
+                        "ts": int(wall_time),
                         "spd": round(current_speed, 1),
-                        "cons": snapshot.domain("trip").get("inst_cons", 0.0)
+                        "cons": snapshot.domain("trip").get("inst_cons", 0.0),
                     }
                     if point["spd"] > 1.0:
                         self.trip_trace.append(point)
-
-                    self.last_trace_time = current_time
+                    self.last_trace_time = wall_time
+                if monotonic_time - self.last_checkpoint_time >= self.CHECKPOINT_INTERVAL_S:
+                    self._write_checkpoint(motion.get("odometer", 0.0))
+                    self.last_checkpoint_time = monotonic_time
 
             stop_event.wait(0.5)

--- a/src/services/trip_stats_service.py
+++ b/src/services/trip_stats_service.py
@@ -145,6 +145,70 @@ class TripStatsService(BaseService):
         with self._stats_lock:
             self._accept_running = True
 
+    def export_session_checkpoint(self):
+        """Return the persistent part of an unfinished trip accumulator."""
+        with self._stats_lock:
+            return {
+                "stats": self._stats.copy(),
+                "start_odo": self._start_odo,
+                "session_distance_km": self._session_distance_km,
+                "absolute_fuel_session": self._absolute_fuel_session,
+                "rpm_integral": self._rpm_integral,
+                "engine_time": self._engine_time,
+                "aggressive_time": self._aggressive_time,
+                "motion_time": self._motion_time,
+                "deceleration_without_throttle_dist": self._deceleration_without_throttle_dist,
+                "shift_time_sum": self._shift_time_sum,
+                "shift_count": self._shift_count,
+            }
+
+    def restore_session_checkpoint(self, checkpoint):
+        """Restore an unfinished trip while rebasing transient CAN values."""
+        required = {
+            "stats", "start_odo", "session_distance_km", "absolute_fuel_session",
+            "rpm_integral", "engine_time", "aggressive_time", "motion_time",
+            "deceleration_without_throttle_dist", "shift_time_sum", "shift_count",
+        }
+        if not isinstance(checkpoint, dict) or not required.issubset(checkpoint):
+            raise ValueError("checkpoint de statistiques incomplet")
+
+        with self._stats_lock:
+            restored_stats = checkpoint["stats"]
+            if not isinstance(restored_stats, dict):
+                raise ValueError("statistiques de checkpoint invalides")
+            self._stats.update(restored_stats)
+            self._stats["is_active"] = False
+            self._stats["inst_cons"] = 0.0
+            self._stats["longitudinal_g"] = 0.0
+            self._start_odo = float(checkpoint["start_odo"])
+            self._session_distance_km = max(0.0, float(checkpoint["session_distance_km"]))
+            self._absolute_fuel_session = max(0.0, float(checkpoint["absolute_fuel_session"]))
+            self._rpm_integral = max(0.0, float(checkpoint["rpm_integral"]))
+            self._engine_time = max(0.0, float(checkpoint["engine_time"]))
+            self._aggressive_time = max(0.0, float(checkpoint["aggressive_time"]))
+            self._motion_time = max(0.0, float(checkpoint["motion_time"]))
+            self._deceleration_without_throttle_dist = max(
+                0.0, float(checkpoint["deceleration_without_throttle_dist"])
+            )
+            self._shift_time_sum = max(0.0, float(checkpoint["shift_time_sum"]))
+            self._shift_count = max(0, int(checkpoint["shift_count"]))
+
+            # Values tied to the live process/CAN stream must be rebased. This
+            # prevents fuel or acceleration jumps after a Raspberry Pi reboot.
+            self._last_raw_fuel = None
+            self._last_raw_fuel_time = None
+            self.last_fuel_avg = self._absolute_fuel_session
+            self.last_fuel_inst = None
+            self.last_time_inst = time.monotonic()
+            self.inst_window.clear()
+            self._was_active = False
+            self._is_shifting = False
+            self._shift_start = 0.0
+            self._prev_speed = 0.0
+            self._last_g_time = time.monotonic()
+            self._accept_running = True
+        self._publish_stats()
+
     def _publish_stats(self):
         self.runtime.publish(
             "trip", self._stats_snapshot(), source="trip-stats", ttl_s=0.25,

--- a/tests/test_architecture_contract.py
+++ b/tests/test_architecture_contract.py
@@ -139,6 +139,19 @@ class ArchitectureContractTest(unittest.TestCase):
         for action in ("reset_a", "reset_b", "pause_trip", "resume_trip", "end_trip"):
             self.assertIn(action, menu)
 
+    def test_trip_recovery_is_global_and_apex_displays_live_cost(self):
+        with open(os.path.join(ROOT, "frontend", "components", "AppShell.qml"), encoding="utf-8") as stream:
+            app_shell = stream.read()
+        with open(
+            os.path.join(ROOT, "frontend", "styles", "apex", "pages", "ApexDrivePage.qml"),
+            encoding="utf-8",
+        ) as stream:
+            apex_drive = stream.read()
+        self.assertIn("C.TripRecoveryDialog", app_shell)
+        self.assertIn('executeUiCommand("new_trip"', app_shell)
+        self.assertIn("S.UiState.tripCost", apex_drive)
+        self.assertIn("COÛT EST.", apex_drive)
+
     def test_every_shared_detail_page_can_return_to_the_menu(self):
         pages = os.path.join(ROOT, "frontend", "shared_pages")
         for filename in ("AppearancePage.qml", "VehiclePage.qml", "ServicesPage.qml", "SystemPage.qml", "DiagnosticPage.qml", "DeveloperPage.qml"):

--- a/tests/test_export_service.py
+++ b/tests/test_export_service.py
@@ -6,6 +6,7 @@ import unittest
 from unittest import mock
 
 from src.services.export_service import ExportService
+from src.services.trip_session_manager import TripSessionManager
 
 
 class FakeStorage:
@@ -63,6 +64,22 @@ class ExportServiceTest(unittest.TestCase):
             self.service._check_usb_drives()
 
         self.assertTrue(os.path.isfile(os.path.join(self.mountpoint, "CliOS_Exports", "trip_2.json")))
+
+    def test_active_trip_checkpoint_is_never_exported(self):
+        checkpoint_name = TripSessionManager.CHECKPOINT_FILENAME
+        with open(os.path.join(self.data_dir, checkpoint_name), "w", encoding="utf-8") as stream:
+            stream.write("{}")
+        with open(os.path.join(self.data_dir, "trip_3.json"), "w", encoding="utf-8") as stream:
+            stream.write("{}")
+        with open(os.path.join(self.mountpoint, "clios_export.json"), "w", encoding="utf-8") as stream:
+            stream.write("{}")
+
+        with mock.patch("src.services.export_service.psutil.disk_partitions", return_value=[self._partition()]):
+            self.service._check_usb_drives()
+
+        export_dir = os.path.join(self.mountpoint, "CliOS_Exports")
+        self.assertTrue(os.path.isfile(os.path.join(export_dir, "trip_3.json")))
+        self.assertFalse(os.path.exists(os.path.join(export_dir, checkpoint_name)))
 
     def test_active_storage_key_is_not_exported_to_itself(self):
         active_data = os.path.join(self.mountpoint, "clios", "trips")

--- a/tests/test_trip_session_manager.py
+++ b/tests/test_trip_session_manager.py
@@ -1,0 +1,144 @@
+import json
+import os
+import tempfile
+import threading
+import time
+import unittest
+from unittest.mock import MagicMock
+
+from src.runtime import VehicleRuntime
+from src.services.trip_session_manager import TripSessionManager
+
+
+class FakeTripStats:
+    def __init__(self):
+        self.begin_calls = []
+        self.restored = None
+        self.state = {
+            "stats": {
+                "distance_km": 12.3,
+                "session_fuel_l": 0.8,
+                "session_cost": 1.52,
+                "avg_rpm": 2100,
+                "aggressivity_pct": 4.0,
+                "deceleration_without_throttle_km": 1.2,
+                "longitudinal_g": 0.1,
+            },
+            "start_odo": 1000.0,
+            "session_distance_km": 12.3,
+            "absolute_fuel_session": 0.8,
+            "rpm_integral": 21000.0,
+            "engine_time": 10.0,
+            "aggressive_time": 1.0,
+            "motion_time": 10.0,
+            "deceleration_without_throttle_dist": 1.2,
+            "shift_time_sum": 2.0,
+            "shift_count": 4,
+        }
+
+    def begin_session(self, odometer):
+        self.begin_calls.append(odometer)
+
+    def export_session_checkpoint(self):
+        return json.loads(json.dumps(self.state))
+
+    def restore_session_checkpoint(self, checkpoint):
+        self.restored = checkpoint
+
+    def finish_session(self, _odometer):
+        return self.state["stats"].copy()
+
+
+class TripSessionManagerTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.storage = MagicMock()
+        self.storage.get.side_effect = lambda _key, default=0.0: default
+        self.runtime = VehicleRuntime(self.storage)
+        self.runtime.publish("motion", {"odometer": 1012.3, "speed": 0.0}, source="test")
+        self.runtime.publish("powertrain", {"key_run": True}, source="test")
+        self.stats = FakeTripStats()
+
+    def manager(self):
+        return TripSessionManager(
+            self.runtime, self.storage, self.stats, self.temporary.name
+        )
+
+    def make_suspended_checkpoint(self):
+        manager = self.manager()
+        manager.trip_start_time = time.time() - 120
+        manager.trip_start_odo = 1000.0
+        manager.trip_trace = [{"ts": 1, "spd": 50.0, "cons": 6.0}]
+        manager._publish_session("RUNNING")
+        self.assertTrue(manager._suspend_trip(self.runtime.snapshot()))
+        return manager
+
+    def test_contact_off_suspends_and_writes_atomic_checkpoint(self):
+        self.runtime.publish("powertrain", {"key_run": False}, source="test")
+        manager = self.make_suspended_checkpoint()
+        session = self.runtime.snapshot().domain("session")
+        self.assertEqual(session["state"], "SUSPENDED")
+        checkpoint_path = os.path.join(self.temporary.name, manager.CHECKPOINT_FILENAME)
+        self.assertTrue(os.path.isfile(checkpoint_path))
+        with open(checkpoint_path, encoding="utf-8") as stream:
+            checkpoint = json.load(stream)
+        self.assertEqual(checkpoint["stats_state"]["stats"]["session_cost"], 1.52)
+
+    def test_restart_offers_and_restores_previous_trip(self):
+        original = self.make_suspended_checkpoint()
+        recovered = self.manager()
+        session = self.runtime.snapshot().domain("session")
+        self.assertEqual(session["state"], "RECOVERY_PENDING")
+        self.assertEqual(session["resume_trip"]["distance_km"], 12.3)
+
+        self.assertTrue(recovered.resume_trip())
+        self.assertEqual(self.runtime.snapshot().domain("session")["state"], "RUNNING")
+        self.assertEqual(self.stats.restored["absolute_fuel_session"], 0.8)
+        self.assertEqual(recovered.trip_trace, original.trip_trace)
+
+    def test_new_trip_archives_previous_trip_before_starting(self):
+        self.make_suspended_checkpoint()
+        recovered = self.manager()
+
+        self.assertTrue(recovered.start_new_trip())
+
+        summaries = [
+            name for name in os.listdir(self.temporary.name)
+            if name.startswith("trip_") and name.endswith(".json")
+        ]
+        self.assertEqual(len(summaries), 1)
+        self.assertEqual(self.stats.begin_calls, [1012.3])
+        self.assertEqual(self.runtime.snapshot().domain("session")["state"], "RUNNING")
+
+    def test_timeout_starts_new_trip(self):
+        self.make_suspended_checkpoint()
+        recovered = self.manager()
+        recovered.RECOVERY_TIMEOUT_S = 0.05
+        stop_event = threading.Event()
+        recovered.start(stop_event)
+        deadline = time.monotonic() + 2.0
+        while not self.stats.begin_calls and time.monotonic() < deadline:
+            time.sleep(0.02)
+        stop_event.set()
+        recovered._thread.join(timeout=1.0)
+
+        self.assertEqual(self.stats.begin_calls, [1012.3])
+        self.assertEqual(self.runtime.snapshot().domain("session")["state"], "RUNNING")
+
+    def test_invalid_checkpoint_is_quarantined(self):
+        checkpoint = os.path.join(
+            self.temporary.name, TripSessionManager.CHECKPOINT_FILENAME
+        )
+        with open(checkpoint, "w", encoding="utf-8") as stream:
+            stream.write("not-json")
+
+        manager = self.manager()
+
+        self.assertIsNone(manager._recovery_checkpoint)
+        self.assertEqual(self.runtime.snapshot().domain("session")["state"], "IDLE")
+        self.assertTrue(any(".invalid." in name for name in os.listdir(self.temporary.name)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_trip_stats_service.py
+++ b/tests/test_trip_stats_service.py
@@ -156,6 +156,32 @@ class TripStatsServiceTest(unittest.TestCase):
         self.assertFalse(published["is_active"])
         self.assertEqual(published["distance_km"], 0.0)
 
+    def test_checkpoint_restore_preserves_totals_and_rebases_live_inputs(self):
+        self.service._session_distance_km = 12.3
+        self.service._absolute_fuel_session = 0.8
+        self.service._rpm_integral = 21000.0
+        self.service._engine_time = 10.0
+        self.service._stats.update({
+            "distance_km": 12.3,
+            "session_fuel_l": 0.8,
+            "session_cost": 1.36,
+            "inst_cons": 7.2,
+        })
+        checkpoint = self.service.export_session_checkpoint()
+        self.service.reset_session(10012.3)
+
+        self.service.restore_session_checkpoint(checkpoint)
+
+        self.assertEqual(self.service._session_distance_km, 12.3)
+        self.assertEqual(self.service._absolute_fuel_session, 0.8)
+        self.assertEqual(self.service._rpm_integral, 21000.0)
+        self.assertEqual(self.service._last_raw_fuel, None)
+        self.assertTrue(self.service._accept_running)
+        published = self.runtime.snapshot().domain("trip")
+        self.assertEqual(published["distance_km"], 12.3)
+        self.assertEqual(published["session_cost"], 1.36)
+        self.assertEqual(published["inst_cons"], 0.0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/qml_smoke.py
+++ b/tools/qml_smoke.py
@@ -393,7 +393,7 @@ def main():
                 failures.append(f"capture impossible: {target}")
 
     updater_states = ["IDLE", "CHECKING", "AVAILABLE", "DOWNLOADING", "STAGED", "ACTIVATING", "UP_TO_DATE", "ERROR"]
-    specials = ["warnings", "paused", "missing-data", "confirmation", "services-expanded", "legacy-dashboard", "jdm-motion"] + ["updater-" + value for value in updater_states]
+    specials = ["warnings", "paused", "trip-recovery", "missing-data", "confirmation", "services-expanded", "legacy-dashboard", "jdm-motion"] + ["updater-" + value for value in updater_states]
     special_index = {"value": 0}
 
     def run_special():
@@ -521,6 +521,19 @@ def main():
             emit_runtime()
         elif name == "paused":
             bridge._session_state["state"] = "PAUSED"
+            bridge._trip_state["is_active"] = False
+            emit_runtime()
+        elif name == "trip-recovery":
+            bridge._session_state = {
+                "state": "RECOVERY_PENDING",
+                "resume_available": True,
+                "resume_seconds": 24,
+                "resume_trip": {
+                    "date": "2026-08-24T12:45:00",
+                    "distance_km": 12.3,
+                    "cost_eur": 1.52,
+                },
+            }
             bridge._trip_state["is_active"] = False
             emit_runtime()
         elif name == "missing-data":


### PR DESCRIPTION
This pull request implements a robust trip recovery feature, allowing users to resume or discard an interrupted driving session after an unexpected shutdown. It introduces new UI components for trip recovery, updates session state handling, and enhances the backend logic to manage trip checkpoints and recovery flows. Additionally, it improves the display of trip cost and session statuses in the UI.

**Trip Recovery Feature:**

* Added a new `TripRecoveryDialog` component that prompts the user to resume or start a new trip after an unexpected shutdown, displaying trip summary and a countdown timer (`frontend/shared_pages/components/TripRecoveryDialog.qml`, `frontend/components/AppShell.qml`, `frontend/state/UiState.qml`). [[1]](diffhunk://#diff-43b8e45810187d895972ff73219d297bf41e9ddfcb8e691817b13627f1b05a83R1-R119) [[2]](diffhunk://#diff-ff7445be8838bb867c05a4d6b32121d1c5a62f78284e8f762527a2563156c4c3R122-R130) [[3]](diffhunk://#diff-c0eb4ea087477a74a7685a0dd73675b150d820f90b65126fc3b1aa89e74ec183R136-R138)
* Implemented backend logic for checkpointing and recovery: the `TripSessionManager` now saves checkpoints, detects interrupted trips, and allows resuming or starting a new trip, publishing relevant session states and summaries (`src/services/trip_session_manager.py`).

**Session State and UI Enhancements:**

* Updated session state logic to include new states (`SUSPENDED`, `RECOVERY_PENDING`), and adjusted UI elements to reflect these, including status colors, labels, and button behaviors (`frontend/styles/apex/pages/ApexDrivePage.qml`). [[1]](diffhunk://#diff-80c78ff4cb24dde6e5d3604c2f213e3f4bd40b6a93ab345d7c009bd30551c71dL165-R172) [[2]](diffhunk://#diff-80c78ff4cb24dde6e5d3604c2f213e3f4bd40b6a93ab345d7c009bd30551c71dL202-R203) [[3]](diffhunk://#diff-80c78ff4cb24dde6e5d3604c2f213e3f4bd40b6a93ab345d7c009bd30551c71dR213)
* Added display of estimated trip cost as a new metric in the drive page UI (`frontend/styles/apex/pages/ApexDrivePage.qml`).

**Command Routing:**

* Added support for a new UI command to start a new trip from the recovery dialog (`src/bridge/ui_command_router.py`).