### PR TITLE
fix(mock): quantize the wrapping fuel counter

### DIFF
--- a/src/services/trip_stats_service.py
+++ b/src/services/trip_stats_service.py
@@ -34,6 +34,8 @@ class TripStatsService(BaseService):
         fuel_config = config.get("fuel", {})
         # Valeur observée sur le compteur 8 bits de la Clio (256 * 0,00008 L).
         self._fuel_counter_modulus_l = float(fuel_config.get("counter_modulus_l", 0.02048))
+        self._fuel_counter_steps = 256
+        self._fuel_counter_step_l = self._fuel_counter_modulus_l / self._fuel_counter_steps
         self._max_fuel_rate_lph = float(fuel_config.get("max_plausible_rate_lph", 80.0))
 
         # Verrou d'accès aux statistiques partagées.
@@ -215,6 +217,37 @@ class TripStatsService(BaseService):
             units=self.TRIP_UNITS,
         )
 
+    def _fuel_counter_delta(self, raw_fuel, current_time):
+        """Return a quantized 8-bit counter delta, including a real wrap."""
+        current_tick = int(round(float(raw_fuel) / self._fuel_counter_step_l))
+        current_tick %= self._fuel_counter_steps
+        canonical_value = current_tick * self._fuel_counter_step_l
+
+        if self._last_raw_fuel is None:
+            self._last_raw_fuel = canonical_value
+            self._last_raw_fuel_time = current_time
+            return 0.0
+
+        previous_tick = int(round(self._last_raw_fuel / self._fuel_counter_step_l))
+        previous_tick %= self._fuel_counter_steps
+        if current_tick == previous_tick:
+            return 0.0
+
+        delta_ticks = (current_tick - previous_tick) % self._fuel_counter_steps
+        delta_f = delta_ticks * self._fuel_counter_step_l
+        elapsed = max(0.001, current_time - self._last_raw_fuel_time)
+        plausible_max = max(0.002, self._max_fuel_rate_lph / 3600.0 * elapsed * 3.0)
+        if delta_f > plausible_max:
+            self.logger.warning(
+                f"Saut compteur carburant rejeté: {delta_f:.5f} L",
+                extra={"error_code": "FUEL_COUNTER_IMPLAUSIBLE"},
+            )
+            delta_f = 0.0
+
+        self._last_raw_fuel = canonical_value
+        self._last_raw_fuel_time = current_time
+        return delta_f
+
     def finish_session(self, last_odo):
         """Atomically captures the final trip values and resets the accumulator."""
         with self._stats_lock:
@@ -349,26 +382,7 @@ class TripStatsService(BaseService):
                         self._was_active = is_active
 
                     if raw_fuel is not None:
-                        if self._last_raw_fuel is not None and raw_fuel != self._last_raw_fuel:
-                            delta_f = raw_fuel - self._last_raw_fuel
-                            if delta_f < 0:
-                                delta_f += self._fuel_counter_modulus_l
-                            elapsed = max(0.001, current_time - self._last_raw_fuel_time)
-                            plausible_max = max(0.002, self._max_fuel_rate_lph / 3600.0 * elapsed * 3.0)
-                            if delta_f < 0.0 or delta_f > plausible_max:
-                                self.logger.warning(
-                                    f"Saut compteur carburant rejeté: {delta_f:.5f} L",
-                                    extra={"error_code": "FUEL_COUNTER_IMPLAUSIBLE"},
-                                )
-                                delta_f = 0.0
-                            self._last_raw_fuel = raw_fuel
-                            self._last_raw_fuel_time = current_time
-                        elif self._last_raw_fuel is not None:
-                            delta_f = 0.0
-                        else:
-                            delta_f = 0.0
-                            self._last_raw_fuel = raw_fuel
-                            self._last_raw_fuel_time = current_time
+                        delta_f = self._fuel_counter_delta(raw_fuel, current_time)
 
                         if is_active:
                             self._absolute_fuel_session += delta_f

--- a/tests/test_trip_stats_service.py
+++ b/tests/test_trip_stats_service.py
@@ -182,6 +182,39 @@ class TripStatsServiceTest(unittest.TestCase):
         self.assertEqual(published["session_cost"], 1.36)
         self.assertEqual(published["inst_cons"], 0.0)
 
+    def test_equivalent_mock_counter_floats_do_not_fake_a_full_wrap(self):
+        tick = 14
+        decoded_value = tick * 0.00008
+        directly_published_value = round(decoded_value, 5)
+        self.service._last_raw_fuel = decoded_value
+        self.service._last_raw_fuel_time = 10.0
+
+        with unittest.mock.patch.object(self.service.logger, "warning") as warning:
+            delta = self.service._fuel_counter_delta(directly_published_value, 10.02)
+
+        self.assertEqual(delta, 0.0)
+        warning.assert_not_called()
+
+    def test_real_fuel_counter_wrap_adds_one_tick(self):
+        self.service._last_raw_fuel = 255 * 0.00008
+        self.service._last_raw_fuel_time = 10.0
+
+        with unittest.mock.patch.object(self.service.logger, "warning") as warning:
+            delta = self.service._fuel_counter_delta(0.0, 10.02)
+
+        self.assertAlmostEqual(delta, 0.00008)
+        warning.assert_not_called()
+
+    def test_implausible_counter_jump_is_still_rejected(self):
+        self.service._last_raw_fuel = 0.0
+        self.service._last_raw_fuel_time = 10.0
+
+        with unittest.mock.patch.object(self.service.logger, "warning") as warning:
+            delta = self.service._fuel_counter_delta(100 * 0.00008, 10.02)
+
+        self.assertEqual(delta, 0.0)
+        warning.assert_called_once()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This pull request improves the handling of the 8-bit fuel counter in the `TripStatsService` to ensure more accurate and robust fuel consumption calculations, especially in the presence of counter wraps and floating-point imprecision. The main changes include introducing a quantized tick-based delta computation, refactoring the main loop to use this logic, and adding targeted unit tests to validate the new behavior.

**Fuel counter logic improvements:**

* Added `_fuel_counter_steps` and `_fuel_counter_step_l` to the constructor to represent the number of counter steps and the fuel value per step, enabling quantized tick-based calculations.
* Introduced the `_fuel_counter_delta` method, which accurately computes the fuel delta by quantizing raw float values to counter ticks, properly handling counter wraps, and filtering out implausible jumps.
* Refactored the main loop in `_run` to use `_fuel_counter_delta` instead of the previous float-based delta calculation, improving reliability and code clarity.

**Testing enhancements:**

* Added unit tests to ensure that equivalent float values do not trigger false wraps, real counter wraps are handled correctly, and implausible jumps are still rejected, increasing confidence in the new logic.