### PR TITLE
Fix/pi fast boot

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -41,6 +41,8 @@ NON_INTERACTIVE=0
 DO_UNINSTALL=0
 KIOSK_INSTALLED=0
 KIOSK_AUTOSTART_ENABLED=0
+FAST_BOOT_APPLIED=()
+FAST_BOOT_SKIPPED=()
 
 # ------------------------------------------------------------------------------
 # 2. Couleurs & Mise en page CLI
@@ -160,6 +162,23 @@ safe_systemctl() {
         run_sudo_cmd "$action_desc" systemctl "$@"
     else
         log_info "systemctl non disponible dans cet environnement (${action_desc} ignoré)."
+    fi
+}
+
+systemd_unit_exists() {
+    local unit="$1"
+    if [[ $DRY_RUN -eq 1 ]]; then
+        return 0
+    fi
+    command -v systemctl &>/dev/null && systemctl cat "$unit" &>/dev/null
+}
+
+disable_systemd_unit_if_present() {
+    local unit="$1"
+    if systemd_unit_exists "$unit"; then
+        safe_systemctl "Désactivation de ${unit}" disable "$unit" 2>/dev/null || true
+    else
+        log_info "${unit} absent : aucune action nécessaire."
     fi
 }
 
@@ -879,8 +898,8 @@ log_step "6/6" "Optimisations Fast-Boot (Démarrage Rapide)"
 if [[ $VENV_ONLY -eq 1 || "$OS_NAME" != "Linux" ]]; then
     log_info "Étape Fast-Boot ignorée (mode venv-only ou système non-Linux)."
 else
-    echo -e "Accélération du temps de démarrage (gain estimé : ~10 à 12 secondes) :"
-    echo -e "Désactivation des services de fond lents (NetworkManager-wait-online, timers apt, swap)."
+    echo -e "Accélération prudente du démarrage, sans désactiver le réseau, le BLE, l'USB, le CAN ni l'updater."
+    echo -e "Chaque groupe sensible est confirmé séparément et reste réversible."
     if prompt_confirm "Souhaitez-vous désactiver ces services lents au démarrage ?" "N"; then
         SLOW_SERVICES=(
             NetworkManager-wait-online.service
@@ -891,14 +910,53 @@ else
             rpi-eeprom-update.service
         )
         for srv in "${SLOW_SERVICES[@]}"; do
-            safe_systemctl "Désactivation de ${srv}" disable "${srv}" 2>/dev/null || true
+            disable_systemd_unit_if_present "${srv}"
         done
+        FAST_BOOT_APPLIED+=("services de fond non essentiels")
         log_success "Services lents désactivés avec succès."
-        echo -e "\n ${C_CYAN}ℹ${C_RESET} ${C_BOLD}Astuce Matérielle :${C_RESET} Pour optimiser également l'EEPROM et le fichier /boot/firmware/config.txt,"
-        echo -e "   consultez le guide détaillé : ${C_CYAN}installation/guide_optimisation_boot_rpi5.md${C_RESET}"
     else
-        log_info "Optimisations Fast-Boot ignorées."
+        FAST_BOOT_SKIPPED+=("services de fond non essentiels")
+        log_info "Désactivation des services de fond ignorée."
     fi
+
+    KIOSK_UNIT_AVAILABLE=0
+    if [[ $KIOSK_INSTALLED -eq 1 ]] || systemd_unit_exists clios.service; then
+        KIOSK_UNIT_AVAILABLE=1
+    fi
+    if [[ $KIOSK_UNIT_AVAILABLE -eq 1 ]]; then
+        echo -e "\nLe mode kiosque CliOS n'a pas besoin de LightDM. Le changement prendra effet au prochain démarrage."
+        if prompt_confirm "Désactiver LightDM et démarrer par défaut sur multi-user.target ?" "N"; then
+            disable_systemd_unit_if_present lightdm.service
+            safe_systemctl "Sélection du démarrage kiosque sans bureau" set-default multi-user.target
+            FAST_BOOT_APPLIED+=("mode kiosque sans LightDM")
+            log_success "Mode kiosque configuré sans arrêter la session graphique actuelle."
+        else
+            FAST_BOOT_SKIPPED+=("mode kiosque sans LightDM")
+            log_info "LightDM et la cible par défaut sont inchangés."
+        fi
+    else
+        FAST_BOOT_SKIPPED+=("mode kiosque sans LightDM (CliOS non installé)")
+        log_info "Optimisation LightDM non proposée : clios.service n'est pas installé."
+    fi
+
+    echo -e "\n${C_YELLOW}${C_BOLD}Cloud-init ne doit être désactivé qu'après le provisioning initial.${C_RESET}"
+    echo -e "Cette action conserve sa configuration mais empêche ses unités de ralentir les prochains boots."
+    if prompt_confirm "Cette machine est-elle provisionnée et peut-on désactiver cloud-init ?" "N"; then
+        if [[ -e /etc/cloud/cloud-init.disabled ]]; then
+            log_info "cloud-init est déjà désactivé."
+        else
+            run_sudo_cmd "Désactivation réversible de cloud-init" mkdir -p /etc/cloud
+            run_sudo_cmd "Création du marqueur cloud-init.disabled" touch /etc/cloud/cloud-init.disabled
+        fi
+        FAST_BOOT_APPLIED+=("cloud-init désactivé")
+        log_success "Cloud-init sera ignoré aux prochains démarrages."
+    else
+        FAST_BOOT_SKIPPED+=("cloud-init conservé")
+        log_info "Cloud-init reste actif."
+    fi
+
+    echo -e "\n ${C_CYAN}ℹ${C_RESET} ${C_BOLD}Astuce matérielle :${C_RESET} contrôlez l'EEPROM et config.txt avec"
+    echo -e "   ${C_CYAN}installation/guide_optimisation_boot_rpi5.md${C_RESET}, sans ajouter d'overclocking non validé."
 fi
 
 # ------------------------------------------------------------------------------
@@ -923,4 +981,17 @@ else
     echo -e "  ${C_CYAN}./clios --mock${C_RESET}          # Simulation sans matériel"
     echo -e "  ${C_CYAN}./clios --ui cli --mock${C_RESET} # Terminal interactif"
     echo -e "  ${C_CYAN}./clios --help${C_RESET}          # Options disponibles\n"
+fi
+
+if [[ ${#FAST_BOOT_APPLIED[@]} -gt 0 ]]; then
+    log_success "Fast-Boot appliqué : ${FAST_BOOT_APPLIED[*]}"
+fi
+if [[ ${#FAST_BOOT_SKIPPED[@]} -gt 0 ]]; then
+    log_info "Fast-Boot non appliqué : ${FAST_BOOT_SKIPPED[*]}"
+fi
+if [[ ${#FAST_BOOT_APPLIED[@]} -gt 0 ]]; then
+    echo -e "\n${C_BOLD}Restauration des optimisations Fast-Boot :${C_RESET}"
+    echo -e "  ${C_CYAN}sudo systemctl set-default graphical.target${C_RESET}"
+    echo -e "  ${C_CYAN}sudo systemctl enable lightdm.service NetworkManager-wait-online.service${C_RESET}"
+    echo -e "  ${C_CYAN}sudo rm -f /etc/cloud/cloud-init.disabled${C_RESET}"
 fi

--- a/installation/guide_optimisation_boot_rpi5.md
+++ b/installation/guide_optimisation_boot_rpi5.md
@@ -1,9 +1,11 @@
 # ⚡ Guide d'Optimisation du Démarrage Rapide (Fast-Boot) — Raspberry Pi 5
 
 > [!TIP]
-> L'étape 6 de l'installateur interactif `./install.sh` permet de désactiver automatiquement les services lents au démarrage (Étape 3 ci-dessous). Les étapes 1 et 2 concernent l'EEPROM et le firmware et s'éditent manuellement.
+> L'étape 6 de `./install.sh` propose séparément les services de fond, le mode
+> kiosque sans LightDM et la désactivation de cloud-init. Elle conserve toujours
+> NetworkManager, Bluetooth, Avahi, SSH, USB, CAN et l'updater CliOS.
 
-Ce guide regroupe les étapes de configuration système et matérielle à effectuer sur un **Raspberry Pi 5** pour réduire son temps de démarrage au minimum (passage de ~31 secondes à ~19 secondes).
+Ce guide regroupe les étapes de configuration système et matérielle à effectuer sur un **Raspberry Pi 5**. Mesurez chaque modification : le temps utile est celui du premier frame CliOS, pas seulement celui où une cible systemd devient active.
 
 ---
 
@@ -45,12 +47,6 @@ Ajoutez ou modifiez les lignes suivantes dans la section `[all]` :
 disable_splash=1
 boot_delay=0
 
-# Fréquence CPU maximale dès les premières secondes
-initial_turbo=30
-
-# Overclocking du bus MicroSD compatible UHS-I
-dtparam=sd_overclock=100
-
 # Désactivation des sondes de détection caméra inutiles
 camera_auto_detect=0
 
@@ -65,6 +61,10 @@ display_auto_detect=1
 
 > [!CAUTION]
 > Sur Raspberry Pi 5, veillez à toujours laisser **`auto_initramfs=1`**. Le pilote graphique 3D matériel (VC4/V3D) et la puce d'E/S RP1 en ont impérativement besoin au démarrage.
+
+N'ajoutez pas `initial_turbo` ou d'overclocking de la carte SD sans validation
+matérielle. Après toute modification, vérifiez la température et les alertes avec
+`vcgencmd get_throttled`.
 
 ---
 
@@ -84,6 +84,32 @@ sudo systemctl disable apt-daily.timer apt-daily-upgrade.timer man-db.timer
 # 3. Désactiver le fichier d'échange swap lent et la vérification de màj EEPROM
 sudo systemctl disable dphys-swapfile.service
 sudo systemctl disable rpi-eeprom-update.service
+
+# 4. Kiosque autonome : ne pas lancer un second gestionnaire graphique
+sudo systemctl disable lightdm.service
+sudo systemctl set-default multi-user.target
+```
+
+CliOS doit rester rattaché à `multi-user.target`. Remplacer son `WantedBy` par
+`basic.target` ne le rend pas prêt plus tôt : cette directive choisit qui active
+le service, elle ne supprime pas ses contraintes d'ordre et de session.
+
+Lorsque la machine est définitivement provisionnée, cloud-init peut être
+désactivé de manière réversible :
+
+```bash
+sudo touch /etc/cloud/cloud-init.disabled
+```
+
+Ne faites pas cette opération sur une image dont la création du compte, les clés
+SSH ou le réseau dépendent encore du premier démarrage cloud-init.
+
+Pour revenir à la configuration de bureau :
+
+```bash
+sudo systemctl set-default graphical.target
+sudo systemctl enable lightdm.service NetworkManager-wait-online.service
+sudo rm -f /etc/cloud/cloud-init.disabled
 ```
 
 ---
@@ -103,4 +129,7 @@ sudo reboot
 Après le redémarrage, vous pouvez mesurer le temps exact de démarrage avec la commande :
 ```bash
 systemd-analyze
+systemd-analyze critical-chain clios.service
+systemctl show clios.service -p ActiveEnterTimestampMonotonic -p NRestarts
+journalctl -b -u clios.service -o short-monotonic --no-pager
 ```

--- a/installation/systemd/clios.service.in
+++ b/installation/systemd/clios.service.in
@@ -3,7 +3,9 @@ Description=CliOS Automotive Dashboard (Wayland Kiosk via Cage)
 After=systemd-user-sessions.service
 
 [Service]
-Type=simple
+Type=notify
+NotifyAccess=all
+TimeoutStartSec=45
 User=@USER@
 SupplementaryGroups=clios
 StateDirectory=clios

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ import socket
 import threading
 import time
 
-PROCESS_STARTED_NS = time.monotonic_ns()
+from src.startup_clock import PROCESS_STARTED_NS
 
 from PySide6.QtQuickControls2 import QQuickStyle
 from PySide6.QtWidgets import QApplication

--- a/main.py
+++ b/main.py
@@ -1,8 +1,13 @@
 import os
 import sys
 import argparse
+import json
 import platform
+import socket
 import threading
+import time
+
+PROCESS_STARTED_NS = time.monotonic_ns()
 
 from PySide6.QtQuickControls2 import QQuickStyle
 from PySide6.QtWidgets import QApplication
@@ -47,6 +52,55 @@ from src.update_safety import UpdateSafety
 from src.cli_debug import ui_loop
 
 
+def _atomic_write(path: str, payload: str) -> None:
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    temporary = path + ".tmp"
+    with open(temporary, "w", encoding="utf-8") as stream:
+        stream.write(payload)
+        stream.flush()
+        os.fsync(stream.fileno())
+    os.replace(temporary, path)
+
+
+def write_startup_status(phase: str, logger=None) -> bool:
+    """Publie la dernière phase atteinte pour le superviseur de release."""
+    status_path = os.environ.get("CLIOS_STARTUP_STATUS")
+    elapsed_ms = (time.monotonic_ns() - PROCESS_STARTED_NS) // 1_000_000
+    if status_path:
+        try:
+            _atomic_write(status_path, json.dumps({"phase": phase, "elapsed_ms": elapsed_ms}))
+        except OSError as exc:
+            if logger is not None:
+                logger.error(
+                    f"Écriture de la phase de démarrage impossible: {exc}",
+                    extra={"error_code": "APP_STARTUP_STATUS_WRITE"},
+                )
+            return False
+    if logger is not None:
+        logger.info(
+            f"Phase de démarrage: {phase} ({elapsed_ms} ms)",
+            extra={"error_code": "APP_STARTUP_PHASE", "phase": phase, "elapsed_ms": elapsed_ms},
+        )
+    return True
+
+
+def notify_systemd_ready(status: str = "CliOS prêt") -> bool:
+    """Envoie READY=1 sans dépendre du module Python systemd."""
+    notify_socket = os.environ.get("NOTIFY_SOCKET")
+    if not notify_socket:
+        return False
+    address = f"\0{notify_socket[1:]}" if notify_socket.startswith("@") else notify_socket
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM) as notifier:
+            notifier.connect(address)
+            notifier.sendall(f"READY=1\nSTATUS={status}".encode("utf-8"))
+        return True
+    except OSError:
+        return False
+
+
 def ensure_supported_pyside(is_gui: bool, allow_unsupported: bool) -> None:
     """Bloque les versions PySide6 connues instables en mode GUI."""
     if not is_gui:
@@ -86,21 +140,21 @@ def load_system_version(root_dir: str) -> str:
         return "unknown"
 
 
-def write_health_marker() -> None:
+def write_health_marker(logger=None) -> bool:
     """Signale au lanceur qu'initialisation Python et chargement QML ont réussi."""
     marker = os.environ.get("CLIOS_HEALTH_MARKER")
     if not marker:
-        return
+        return True
     try:
-        os.makedirs(os.path.dirname(marker), exist_ok=True)
-        temporary = marker + ".tmp"
-        with open(temporary, "w", encoding="utf-8") as stream:
-            stream.write(os.environ.get("CLIOS_RELEASE_VERSION", "healthy"))
-            stream.flush()
-            os.fsync(stream.fileno())
-        os.replace(temporary, marker)
-    except OSError:
-        pass
+        _atomic_write(marker, os.environ.get("CLIOS_RELEASE_VERSION", "healthy"))
+        return True
+    except OSError as exc:
+        if logger is not None:
+            logger.error(
+                f"Écriture du marqueur de santé impossible: {exc}",
+                extra={"error_code": "APP_HEALTH_MARKER_WRITE"},
+            )
+        return False
 
 
 def setup_services(runtime, storage, orchestrator, can_provider, vehicle_config, profile_manager, engine_dir,
@@ -166,6 +220,7 @@ def setup_services(runtime, storage, orchestrator, can_provider, vehicle_config,
 
 
 def main():
+    write_startup_status("imports_loaded")
     # --- 1. Arguments & Environnement ---
     parser = argparse.ArgumentParser()
     parser.add_argument('--ui', choices=['cli', 'gui'], default='gui')
@@ -192,6 +247,7 @@ def main():
     install_crash_hooks(LOG_DIR)
     set_global_context(ui=args.ui, mock=args.mock)
     logger = get_logger("Main")
+    write_startup_status("logging_ready", logger)
     CAN_DIR = os.path.join(STATIC_DATA_DIR, "can")
     STATIC_CONFIG_DIR = os.path.join(STATIC_DATA_DIR, "config")
     CONFIG_DIR = storage_mgr.prepare_config_dir(STATIC_CONFIG_DIR)
@@ -218,6 +274,7 @@ def main():
         }
     else:
         vehicle_config = profile_manager.load_active_config()
+    write_startup_status("profile_loaded", logger)
 
     storage = PersistentStorage(profile_manager.get_save_path())
     runtime = VehicleRuntime(storage)
@@ -309,6 +366,7 @@ def main():
             runtime_targets["bridge"] = bridge
             bridge.storage = storage
             engine.rootContext().setContextProperty("bridge", bridge)
+            write_startup_status("bridge_ready", logger)
 
             # Notifications Système
             notif_service = NotificationService(runtime, bridge.send_notification, storage)
@@ -322,11 +380,36 @@ def main():
             engine.load(os.path.join(BASE_DIR, "frontend", "main.qml"))
             if not engine.rootObjects():
                 sys.exit(-1)
+            write_startup_status("qml_loaded", logger)
 
-            # Démarrage des services d'arrière-plan dès le premier tick d'affichage
+            # Le premier frame est le vrai critère de santé. Les services et
+            # scans non critiques démarrent seulement après son affichage.
             from PySide6.QtCore import QTimer
-            QTimer.singleShot(0, orchestrator.start_all)
-            QTimer.singleShot(1000, write_health_marker)
+            startup_complete = False
+
+            def complete_startup():
+                nonlocal startup_complete
+                if startup_complete:
+                    return
+                startup_complete = True
+                write_startup_status("first_frame", logger)
+                marker_written = write_health_marker(logger)
+                notified = marker_written and notify_systemd_ready("CliOS : premier frame affiché")
+                if marker_written and os.environ.get("NOTIFY_SOCKET") and not notified:
+                    logger.error(
+                        "Notification READY=1 impossible",
+                        extra={"error_code": "APP_SYSTEMD_NOTIFY"},
+                    )
+                QTimer.singleShot(0, orchestrator.start_all)
+                QTimer.singleShot(0, bridge.start_background_tasks)
+
+            root_window = engine.rootObjects()[0]
+            frame_signal = getattr(root_window, "frameSwapped", None)
+            if frame_signal is not None:
+                frame_signal.connect(complete_startup)
+            else:
+                # Repli pour les plateformes Qt sans QQuickWindow.
+                QTimer.singleShot(0, complete_startup)
 
             # Outils de Mock
             mock_panel = None

--- a/src/qt_bridge.py
+++ b/src/qt_bridge.py
@@ -115,6 +115,7 @@ class DashboardBridge(QObject):
         self._last_updater_status_signature = None
         self._network_was_online = False
         self._network_information = None
+        self._background_tasks_started = False
 
         with open(config_path, 'r') as f:
             self._config = json.load(f)
@@ -148,14 +149,19 @@ class DashboardBridge(QObject):
         self.timer_updater.timeout.connect(self._poll_updater_status)
         self.timer_updater.start(1000)
 
-        self._setup_network_information()
-        self._network_controller.refresh()
-        self._system_controller.refresh_maintenance_state()
-
         self.needs_restart = False
         self.requested_power_action = ""
         self.exitRequested.connect(self._quit_qt)
         self._update_health()
+
+    def start_background_tasks(self):
+        """Lance les détections non critiques après le premier frame QML."""
+        if self._closed or self._background_tasks_started:
+            return
+        self._background_tasks_started = True
+        self._setup_network_information()
+        self._network_controller.refresh()
+        self._system_controller.refresh_maintenance_state()
 
     # Boucles de rafraîchissement.
     def _update_fast_data(self):

--- a/src/startup_clock.py
+++ b/src/startup_clock.py
@@ -1,0 +1,6 @@
+"""Horloge capturée avant le chargement des dépendances applicatives lourdes."""
+
+import time
+
+
+PROCESS_STARTED_NS = time.monotonic_ns()

--- a/tests/test_launcher_systemd.py
+++ b/tests/test_launcher_systemd.py
@@ -1,7 +1,7 @@
 import pathlib
 import unittest
 
-from tools.clios_launcher import application_args
+from tools.clios_launcher import application_args, last_startup_phase
 from tools.generate_systemd import render_service
 
 
@@ -20,6 +20,23 @@ class LauncherSystemdTest(unittest.TestCase):
         for payload in (service, installer):
             self.assertNotIn("WantedBy=graphical.target", payload)
             self.assertNotIn("After=graphical.target", payload)
+
+    def test_service_reports_ready_only_after_the_first_frame(self):
+        service = render_service("clios", 1000)
+        self.assertIn("Type=notify", service)
+        self.assertIn("NotifyAccess=all", service)
+        self.assertIn("TimeoutStartSec=45", service)
+        self.assertIn("After=systemd-user-sessions.service", service)
+
+    def test_launcher_reports_the_last_bounded_startup_phase(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            status = pathlib.Path(tmp) / "startup.json"
+            status.write_text('{"phase": "qml_loaded", "elapsed_ms": 4321}', encoding="utf-8")
+            self.assertEqual(last_startup_phase(status), "qml_loaded (4321 ms)")
+            status.write_text("not-json", encoding="utf-8")
+            self.assertEqual(last_startup_phase(status), "inconnue")
 
     def test_installer_and_tests_use_the_authoritative_unit_generator(self):
         installer = (ROOT / "install.sh").read_text(encoding="utf-8")
@@ -65,6 +82,17 @@ class LauncherSystemdTest(unittest.TestCase):
         self.assertIn("CliOS est installé dans /opt/clios/current", installer)
         self.assertIn("Voulez-vous démarrer CliOS maintenant ?", installer)
         self.assertIn('start clios.service', installer)
+
+    def test_fast_boot_keeps_hardware_features_and_uses_separate_prompts(self):
+        installer = (ROOT / "install.sh").read_text(encoding="utf-8")
+        self.assertIn("Souhaitez-vous désactiver ces services lents", installer)
+        self.assertIn("Désactiver LightDM et démarrer par défaut sur multi-user.target", installer)
+        self.assertIn("Cette machine est-elle provisionnée et peut-on désactiver cloud-init", installer)
+        self.assertIn("touch /etc/cloud/cloud-init.disabled", installer)
+        self.assertIn("set-default multi-user.target", installer)
+        self.assertNotIn('disable bluetooth.service', installer)
+        self.assertNotIn('disable NetworkManager.service', installer)
+        self.assertNotIn('disable ssh.service', installer)
 
     def test_overlayfs_permission_is_limited_to_raspi_config_actions(self):
         installer = (ROOT / "install.sh").read_text(encoding="utf-8")

--- a/tests/test_startup_health.py
+++ b/tests/test_startup_health.py
@@ -1,0 +1,52 @@
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import main
+
+
+class StartupHealthTest(unittest.TestCase):
+    def test_health_marker_is_written_atomically(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            marker = Path(tmp) / "health-test"
+            with mock.patch.dict(
+                os.environ,
+                {"CLIOS_HEALTH_MARKER": str(marker), "CLIOS_RELEASE_VERSION": "2.0.1-test"},
+                clear=False,
+            ):
+                self.assertTrue(main.write_health_marker())
+            self.assertEqual(marker.read_text(encoding="utf-8"), "2.0.1-test")
+            self.assertFalse(marker.with_suffix(".tmp").exists())
+
+    def test_health_marker_failure_is_visible(self):
+        logger = mock.Mock()
+        with mock.patch.dict(os.environ, {"CLIOS_HEALTH_MARKER": "/blocked/health"}, clear=False):
+            with mock.patch.object(main, "_atomic_write", side_effect=PermissionError(13, "denied")):
+                self.assertFalse(main.write_health_marker(logger))
+        logger.error.assert_called_once()
+        self.assertEqual(logger.error.call_args.kwargs["extra"]["error_code"], "APP_HEALTH_MARKER_WRITE")
+
+    def test_startup_status_contains_phase_and_elapsed_time(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            status = Path(tmp) / "startup.json"
+            with mock.patch.dict(os.environ, {"CLIOS_STARTUP_STATUS": str(status)}, clear=False):
+                self.assertTrue(main.write_startup_status("qml_loaded"))
+            payload = json.loads(status.read_text(encoding="utf-8"))
+            self.assertEqual(payload["phase"], "qml_loaded")
+            self.assertGreaterEqual(payload["elapsed_ms"], 0)
+
+    def test_systemd_ready_datagram_contains_status(self):
+        notifier = mock.MagicMock()
+        notifier.__enter__.return_value = notifier
+        with mock.patch.object(main.socket, "socket", return_value=notifier):
+            with mock.patch.dict(os.environ, {"NOTIFY_SOCKET": "/run/notify.sock"}, clear=False):
+                self.assertTrue(main.notify_systemd_ready("premier frame"))
+        notifier.connect.assert_called_once_with("/run/notify.sock")
+        notifier.sendall.assert_called_once_with(b"READY=1\nSTATUS=premier frame")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/clios_launcher.py
+++ b/tools/clios_launcher.py
@@ -2,6 +2,7 @@
 """Supervise le premier démarrage d'une release et restaure N-1 sans santé."""
 
 import argparse
+import json
 import os
 import subprocess
 import sys
@@ -19,6 +20,17 @@ def application_args(arguments: list[str]) -> list[str]:
     return arguments[1:] if arguments[:1] == ["--"] else list(arguments)
 
 
+def last_startup_phase(status_path: Path) -> str:
+    """Retourne une description bornée de la dernière phase applicative."""
+    try:
+        payload = json.loads(status_path.read_text(encoding="utf-8"))
+        phase = str(payload.get("phase", "inconnue"))[:80]
+        elapsed_ms = int(payload.get("elapsed_ms", 0))
+        return f"{phase} ({elapsed_ms} ms)"
+    except (OSError, ValueError, TypeError, json.JSONDecodeError):
+        return "inconnue"
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--install-root", default="/opt/clios")
@@ -30,8 +42,15 @@ def main() -> int:
     current = manager.current_link.resolve()
     version = (current / "VERSION").read_text(encoding="utf-8").strip()
     marker = manager.state_root / f"health-{version}"
+    startup_status = manager.state_root / f"startup-{version}.json"
     marker.unlink(missing_ok=True)
-    env = dict(os.environ, CLIOS_HEALTH_MARKER=str(marker), CLIOS_RELEASE_VERSION=version)
+    startup_status.unlink(missing_ok=True)
+    env = dict(
+        os.environ,
+        CLIOS_HEALTH_MARKER=str(marker),
+        CLIOS_RELEASE_VERSION=version,
+        CLIOS_STARTUP_STATUS=str(startup_status),
+    )
     python = current / ".venv/bin/python3"
     if not python.exists():
         python = Path(sys.executable)
@@ -49,6 +68,11 @@ def main() -> int:
     if marker.exists():
         manager.mark_healthy(version)
         return process.wait()
+    print(
+        f"CliOS non sain après {opts.health_timeout:.1f} s; "
+        f"dernière phase: {last_startup_phase(startup_status)}",
+        file=sys.stderr,
+    )
     process.terminate()
     try:
         process.wait(timeout=5)


### PR DESCRIPTION
This pull request implements significant improvements to the fast boot optimization process and the application startup sequence, with a focus on making systemd integration more robust and startup health reporting more precise. The changes also enhance documentation and clarify best practices for Raspberry Pi 5 boot optimization. The most important changes are grouped below:

**Fast Boot Optimization and Systemd Integration:**

* Refactored the fast boot step in `install.sh` to present each optimization (background services, kiosk mode without LightDM, and cloud-init disabling) as separate, reversible options, with explicit tracking of which optimizations were applied or skipped. Added helper functions to safely disable systemd units only if present, and improved user messaging for each step. Summary of applied/skipped optimizations is shown at the end, along with restoration instructions. [[1]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fR44-R45) [[2]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fR168-R184) [[3]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL882-R902) [[4]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL894-R959) [[5]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fR985-R997)
* Updated `clios.service` systemd unit to use `Type=notify`, enabling reliable notification to systemd when the application is fully ready. Increased startup timeout and set `NotifyAccess=all`.

**Application Startup Health and Notification:**

* Added precise startup phase reporting and health marker writing in `main.py`, including atomic file writes, elapsed time measurement, and phase logging. Integrated systemd `READY=1` notification using a custom socket implementation, ensuring systemd only marks the service as ready after the first QML frame is displayed. [[1]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R4-R10) [[2]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R55-R103) [[3]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L89-R157) [[4]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R223) [[5]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R250) [[6]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R277) [[7]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R369) [[8]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R383-R412)

**Frontend Service Initialization:**

* Deferred initialization of non-critical background tasks (network, system state, updater checks) in `qt_bridge.py` until after the first QML frame, to ensure the fastest possible visible startup and accurate health reporting. [[1]](diffhunk://#diff-3779b697715c51069d55c1ae5fee154b0991fa6d87bb01dc77715ffb0a07b334R118) [[2]](diffhunk://#diff-3779b697715c51069d55c1ae5fee154b0991fa6d87bb01dc77715ffb0a07b334L151-R165)

**Documentation and Best Practices:**

* Updated the Raspberry Pi 5 boot optimization guide to reflect the new fast boot process, clarify which services are affected, and discourage unvalidated overclocking. Added clear instructions for reversible changes and precise startup time measurement. [[1]](diffhunk://#diff-51cbe8b28d72e6f92929cb7b1fb5b3b04b55703e257e726c337b11809f06c150L4-R8) [[2]](diffhunk://#diff-51cbe8b28d72e6f92929cb7b1fb5b3b04b55703e257e726c337b11809f06c150L48-L53) [[3]](diffhunk://#diff-51cbe8b28d72e6f92929cb7b1fb5b3b04b55703e257e726c337b11809f06c150R65-R68) [[4]](diffhunk://#diff-51cbe8b28d72e6f92929cb7b1fb5b3b04b55703e257e726c337b11809f06c150R87-R112) [[5]](diffhunk://#diff-51cbe8b28d72e6f92929cb7b1fb5b3b04b55703e257e726c337b11809f06c150R132-R134)

**Testing:**

* Updated the test launcher to import the new startup phase tracking logic.